### PR TITLE
Radio-select for endringsperiode skal utbetales eller ikke -trigger

### DIFF
--- a/src/schemas/ba-sak/begrunnelse/begrunnelse.tsx
+++ b/src/schemas/ba-sak/begrunnelse/begrunnelse.tsx
@@ -13,7 +13,10 @@ import {
 import { triggesAv } from './triggesAv';
 import { endringsårsakTrigger } from './triggere/endringsårsakTrigger';
 import { endretUtbetalingsperiodeTriggere } from './triggere/endretUtbetalingPeriodeTrigger';
-import { endretUtbetalingsperiodeDeltBostedTriggere } from './triggere/endretUtbetalingPeriodeDeltBostedTrigger';
+import {
+  endretUtbetalingsperiodeDeltBostedTriggere,
+  endretUtbetalingsperiodeDeltBostedUtbetalingTrigger,
+} from './triggere/endretUtbetalingPeriodeDeltBostedTrigger';
 import { apiNavnValideringerBegrunnelse } from './valideringer';
 import { øvrigeTriggere } from './triggere/øvrigeTriggere';
 import { utvidetBarnetrygdTriggere } from './triggere/utvidetBarnetrygdTriggere';
@@ -231,6 +234,7 @@ const begrunnelse = {
     endringsårsakTrigger,
     endretUtbetalingsperiodeTriggere,
     endretUtbetalingsperiodeDeltBostedTriggere,
+    endretUtbetalingsperiodeDeltBostedUtbetalingTrigger,
     editor(DokumentNavn.BOKMAAL, 'Bokmål'),
     editor(DokumentNavn.NYNORSK, 'Nynorsk'),
   ],

--- a/src/schemas/ba-sak/begrunnelse/triggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
+++ b/src/schemas/ba-sak/begrunnelse/triggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
@@ -1,9 +1,26 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
-import { endretUtbetalingsperioderDeltBostedTriggereValg, Endringsårsak } from '../typer';
+import {
+  endretUtbetalingsperioderDeltBostedTriggereValg,
+  endretUtbetalingsperioderDeltBostedTriggereValgUtbetaling,
+  Endringsårsak,
+} from '../typer';
 
 const erEndretUtbetalingAvTypeDeltBosted = document =>
   document[BegrunnelseDokumentNavn.ENDRINGSAARSAKER] &&
   document[BegrunnelseDokumentNavn.ENDRINGSAARSAKER].includes(Endringsårsak.DELT_BOSTED);
+
+export const endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = {
+  title: 'Endret utbetalingsperiode - delt bosted: Skal perioden utbetales?',
+  type: SanityTyper.STRING,
+  name: BegrunnelseDokumentNavn.ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_UTBETALING_TRIGGER,
+  of: [{ type: SanityTyper.STRING }],
+  options: {
+    list: endretUtbetalingsperioderDeltBostedTriggereValgUtbetaling,
+    layout: 'radio',
+  },
+  hidden: ({ document }) => !erEndretUtbetalingAvTypeDeltBosted(document),
+  validation: Rule => [Rule.required().error('Du må krysse av for et alternativ.')],
+};
 
 export const endretUtbetalingsperiodeDeltBostedTriggere = {
   title: 'Endret utbetalingsperiode triggere for delt bosted.',

--- a/src/schemas/ba-sak/begrunnelse/triggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
+++ b/src/schemas/ba-sak/begrunnelse/triggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
@@ -19,7 +19,13 @@ export const endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = {
     layout: 'radio',
   },
   hidden: ({ document }) => !erEndretUtbetalingAvTypeDeltBosted(document),
-  validation: Rule => [Rule.required().error('Du må krysse av for et alternativ.')],
+  validation: rule =>
+    rule.custom((currentValue, { document }) => {
+      if (erEndretUtbetalingAvTypeDeltBosted(document) && currentValue === undefined) {
+        return 'Du må krysse av for et alternativ';
+      }
+      return true;
+    }),
 };
 
 export const endretUtbetalingsperiodeDeltBostedTriggere = {

--- a/src/schemas/ba-sak/begrunnelse/typer.ts
+++ b/src/schemas/ba-sak/begrunnelse/typer.ts
@@ -176,11 +176,28 @@ export const endretUtbetalingsperioderTriggereValg = [
 //NB: Endrer du på disse bør du endre i ba-sak først (Før du tester lokalt også)
 export enum EndretUtbetalingsperioderDeltBostedTrigger {
   SKAL_UTBETALES = 'SKAL_UTBETALES',
+  SKAL_IKKE_UTBETALES = 'SKAL_IKKE_UTBETALES',
+  UTBETALING_IKKE_RELEVANT = 'UTBETALING_IKKE_RELEVANT',
 }
 
 export const endretUtbetalingsperioderDeltBostedTriggereValg = [
   {
     title: 'Skal utbetales til søker',
     value: EndretUtbetalingsperioderDeltBostedTrigger.SKAL_UTBETALES,
+  },
+];
+
+export const endretUtbetalingsperioderDeltBostedTriggereValgUtbetaling = [
+  {
+    title: 'Skal utbetales til søker',
+    value: EndretUtbetalingsperioderDeltBostedTrigger.SKAL_UTBETALES,
+  },
+  {
+    title: 'Skal ikke utbetales til søker',
+    value: EndretUtbetalingsperioderDeltBostedTrigger.SKAL_IKKE_UTBETALES,
+  },
+  {
+    title: 'Utbetaling ikke relevant for begrunnelse',
+    value: EndretUtbetalingsperioderDeltBostedTrigger.UTBETALING_IKKE_RELEVANT,
   },
 ];

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -63,6 +63,7 @@ export enum BegrunnelseDokumentNavn {
   VALGFELT_V2 = 'valgfeltV2',
   ENDRINGSAARSAKER = 'endringsaarsaker',
   ENDRET_UTBETALINGSPERIODE_TRIGGERE = 'endretUtbetalingsperiodeTriggere',
-  ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_TRIGGERE = 'endretUtbetalingsperiodeDeltBostedTriggere',
+  ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_UTBETALING_TRIGGER = 'endretUtbetalingsperiodeDeltBostedUtbetalingTrigger',
+  ENDRET_UTBETALINGSPERIODE_DELT_BOSTED_TRIGGERE = 'endretUbetalingsperiodeDeltBostedTriggere',
   UTVIDET_BARNETRYGD_TRIGGERE = 'utvidetBarnetrygdTriggere',
 }


### PR DESCRIPTION
Legge til radio buttons for å kunne velge begrunnelsen sin avhengighet til utbetaling/ikke utbetaling mer eksplisitt. Samt åpne for muligheten at utbetaling/ikke utbetaling ikke er relevant for begrunnelsen. 

Venter med å slette gammel kode til dette er inne.