### PR TITLE
Fiks eøs-hjemler

### DIFF
--- a/src/schemas/ba-sak/begrunnelse/begrunnelse.tsx
+++ b/src/schemas/ba-sak/begrunnelse/begrunnelse.tsx
@@ -18,7 +18,6 @@ import { apiNavnValideringerBegrunnelse } from './valideringer';
 import { validerBegrunnelse } from './validerBegrunnelse';
 import {
   erNasjonalBegrunnelse,
-  hentNasjonalHjemmelRegler,
   rolleSkalVises,
   validerFlettefeltErGyldigForBehandlingstema,
 } from './utils';
@@ -224,8 +223,6 @@ const begrunnelse = {
         layout: 'grid',
         list: hjemler.map(hjemmel => ({ value: hjemmel, title: `§${hjemmel}` })),
       },
-      validation: rule => hentNasjonalHjemmelRegler(rule),
-      hidden: context => !erNasjonalBegrunnelse(context.document),
     },
     {
       title: 'Hjemler fra folketrygdloven',
@@ -236,8 +233,6 @@ const begrunnelse = {
         layout: 'radio',
         list: hjemlerFolketrygdloven.map(hjemmel => ({ value: hjemmel, title: `§${hjemmel}` })),
       },
-      validation: rule => hentNasjonalHjemmelRegler(rule),
-      hidden: context => !erNasjonalBegrunnelse(context.document),
     },
     ...eøsHjemler,
     {

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
@@ -6,11 +6,13 @@ export const erEøsBegrunnelse = document =>
   document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA] &&
   document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA].includes(Behandlingstema.EØS);
 
-export const hentEØSTriggereRegler = rule =>
+export const hentEØSTriggereRegler = rule => [
   hentEØSFeltRegler(
     rule,
     'en EØS-trigger er valgt, men behandlingstema for begrunnelsen er ikke EØS.',
-  );
+  ),
+  rule => [rule.required().error('Du må velge minst ett valg for triggerene')],
+];
 
 export const hentEØSHjemmelRegler = rule =>
   hentEØSFeltRegler(

--- a/src/schemas/ba-sak/begrunnelse/eøs/hjemler.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/hjemler.ts
@@ -13,7 +13,7 @@ export const eøsHjemler = [
     of: [{ type: SanityTyper.STRING }],
     options: {
       layout: 'grid',
-      list: hjemlerEØSForordningen883.map(hjemmel => ({ value: hjemmel, title: `§${hjemmel}` })),
+      list: hjemlerEØSForordningen883.map(hjemmel => ({ value: hjemmel, title: hjemmel })),
     },
     validation: rule => hentEØSHjemmelRegler(rule),
     hidden: context => !erEøsBegrunnelse(context.document),
@@ -25,7 +25,7 @@ export const eøsHjemler = [
     of: [{ type: SanityTyper.STRING }],
     options: {
       layout: 'grid',
-      list: hjemlerEØSForordningen987.map(hjemmel => ({ value: hjemmel, title: `§${hjemmel}` })),
+      list: hjemlerEØSForordningen987.map(hjemmel => ({ value: hjemmel, title: hjemmel })),
     },
     validation: rule => hentEØSHjemmelRegler(rule),
     hidden: context => !erEøsBegrunnelse(context.document),
@@ -39,7 +39,7 @@ export const eøsHjemler = [
       layout: 'grid',
       list: hjemlerSeperasjonsavtalenStorbritannina.map(hjemmel => ({
         value: hjemmel,
-        title: `§${hjemmel}`,
+        title: hjemmel,
       })),
     },
     validation: rule => hentEØSHjemmelRegler(rule),

--- a/src/schemas/ba-sak/begrunnelse/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/utils.ts
@@ -19,12 +19,6 @@ export const hentNasjonaltFeltRegler = (rule, feilmelding: string) =>
     return true;
   });
 
-export const hentNasjonalHjemmelRegler = rule =>
-  hentNasjonaltFeltRegler(
-    rule,
-    'En nasjonal hjemmel er valgt, men behandlingstema for begrunnelsen er ikke nasjonal.',
-  );
-
 export const validerFlettefeltErGyldigForBehandlingstema = (flettefelt, context) => {
   if (
     erEøsBegrunnelse(context.document) &&


### PR DESCRIPTION
Hjemlene som vises på nasjonale begrunnelser skal også brukes for eøs-begrunnelsene.
De eøs-spesifikke hjemlene er ikke paragrafer og skal derfor ikke prefikses med "§".

Denne PRen legger til de nasjonale hjemlene på eøs-begrunnelsene og fjerner "§" for de eøs-spesifikke begrunnelsene
![image](https://user-images.githubusercontent.com/17828446/172360382-3b16dbbf-e9ae-4788-b0aa-995d86336683.png)
