### PR TITLE
Unngå at nasjonal validering vises på EØS-dokument

### DIFF
--- a/src/schemas/ba-sak/begrunnelse/begrunnelse.tsx
+++ b/src/schemas/ba-sak/begrunnelse/begrunnelse.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { BegrunnelseDokumentNavn, DokumentNavn, SanityTyper } from '../../../util/typer';
 import styled from 'styled-components';
+import { lagNasjonalFeltObligatoriskRegel } from './nasjonaleTriggere/utils';
 import {
   Begrunnelsestype,
   begrunnelsestyperTilMenynavn,
@@ -246,7 +247,7 @@ const begrunnelse = {
       options: {
         list: vilkår,
       },
-      validation: rule => rule.required().warning('Vilkår ikke valgt'),
+      validation: rule => lagNasjonalFeltObligatoriskRegel(rule).warning('Vilkår ikke valgt'),
       hidden: context => !erNasjonalBegrunnelse(context.document),
     },
 

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
@@ -28,10 +28,10 @@ export const hentEØSFeltRegler = (rule, feilmelding: string) =>
     return true;
   });
 
-const lagEØSFeltObligatoriskRegel = rule => 
-  rule.custom((currentValue, {document}) => {
+const lagEØSFeltObligatoriskRegel = rule =>
+  rule.custom((currentValue, { document }) => {
     if (erEøsBegrunnelse(document) && currentValue === undefined) {
-      return 'Du må velge minst ett valg for triggerne'
+      return 'Du må velge minst ett valg for triggerne';
     }
     return true;
   });

--- a/src/schemas/ba-sak/begrunnelse/nasjonaleTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/nasjonaleTriggere/utils.ts
@@ -1,7 +1,15 @@
-import { hentNasjonaltFeltRegler } from '../utils';
+import { hentNasjonaltFeltRegler, erNasjonalBegrunnelse } from '../utils';
 
 export const hentNasjonaleTriggereRegler = rule =>
   hentNasjonaltFeltRegler(
     rule,
     'En nasjonal begrunnelse-trigger er valgt, men behandlingstema for begrunnelsen er ikke nasjonal.',
   );
+
+export const lagNasjonalFeltObligatoriskRegel = rule =>
+  rule.custom((currentValue, { document }) => {
+    if (erNasjonalBegrunnelse(document) && currentValue === undefined) {
+      return 'Feltet mangler verdi';
+    }
+    return true;
+  });


### PR DESCRIPTION
Skriver om valideringsregelen for feltet Vilkår på begrunnelser. Vi ønsker at det skal komme en advarsel dersom feltet mangler på nasjonale begrunnelser, men ikke på EØS-begrunnelser. 

Legger til en utilfunksjon som speiler tilsvarende util for EØS, og bruker den i kombinasjon med `.warning()`
<img width="660" alt="image" src="https://user-images.githubusercontent.com/2379098/174620242-9d48ab2a-3ceb-423b-ab34-9cd3fac08d57.png">
