### PR TITLE
Fjern flettefelt som har blitt erstattet av valgfelt

### DIFF
--- a/src/schemas/ba-sak/begrunnelse/typer.ts
+++ b/src/schemas/ba-sak/begrunnelse/typer.ts
@@ -59,7 +59,6 @@ export const flettefelter = [
 ];
 
 export const eøsFlettefelter = [
-  { title: 'Annen forelders aktivitet', value: 'annenForeldersAktivitet' },
   { title: 'Annen forelders aktivitetsland', value: 'annenForeldersAktivitetsland' },
   { title: 'Barnets bostedsland', value: 'barnetsBostedsland' },
   { title: 'Barns fødselsdato', value: 'barnasFodselsdatoer' },


### PR DESCRIPTION
Nå som vi har innført valgfeltet for annen forelders aktivitet (https://github.com/navikt/familie-brev/pull/284) kan og bør vi fjerne det gamle flettefeltet som ikke gir ut gyldige tekster.

Jeg har gått gjennom sanity og endret fra gammelt flettefelt til nytt valgfelt der jeg har funnet det gamle i bruk - men setter pris på om du som leser dette også går og sjekker, for sikkerhets skyld 😇 