### PR TITLE
Lagt til BARN_DØD som øvrig trigger for å håndtere dødsfall begrunnelser

### DIFF
--- a/src/schemas/ba-sak/begrunnelse/typer.ts
+++ b/src/schemas/ba-sak/begrunnelse/typer.ts
@@ -77,6 +77,7 @@ export enum VilkårTriggere {
   SMÅBARNSTILLEGG = 'SMÅBARNSTILLEGG',
   GJELDER_FØRSTE_PERIODE = 'GJELDER_FØRSTE_PERIODE',
   GJELDER_FRA_INNVILGELSESTIDSPUNKT = 'GJELDER_FRA_INNVILGELSESTIDSPUNKT',
+  BARN_DØD = 'BARN_DØD',
 }
 
 export enum VilkårRolle {
@@ -106,6 +107,7 @@ export const øvrigeTriggertyper = [
   VilkårTriggere.ALLTID_AUTOMATISK,
   VilkårTriggere.GJELDER_FØRSTE_PERIODE,
   VilkårTriggere.GJELDER_FRA_INNVILGELSESTIDSPUNKT,
+  VilkårTriggere.BARN_DØD,
 ];
 export const utvidetBarnetrygdTriggertyper = [VilkårTriggere.SMÅBARNSTILLEGG];
 
@@ -147,6 +149,10 @@ export const vilkårTriggerTilMenynavn: Record<VilkårTriggere, { title: string;
   GJELDER_FRA_INNVILGELSESTIDSPUNKT: {
     title: 'Gjelder fra invilgelsestidspunkt',
     value: VilkårTriggere.GJELDER_FRA_INNVILGELSESTIDSPUNKT,
+  },
+  BARN_DØD: {
+    title: 'Barn død',
+    value: VilkårTriggere.BARN_DØD,
   },
 };
 


### PR DESCRIPTION
Lagt til en ny trigger som skal brukes for reduksjon- og opphørs -begrunnelser for "Barn død" "Et eller flere barn død". 