### PR TITLE
Fjerner delmal fra EF ting

### DIFF
--- a/config/deskStructure.ts
+++ b/config/deskStructure.ts
@@ -2,7 +2,7 @@ import S from '@sanity/desk-tool/structure-builder';
 import { hentFraSanity } from '../src/util/sanity';
 import { GrDocumentText } from 'react-icons/gr';
 import { ListItemBuilder } from '@sanity/structure/lib/ListItem';
-import client from 'part:@sanity/base/client';
+import { ekskluderesForEf, erEf } from './felles';
 
 const DOKUMENTER = 'dokumenter';
 
@@ -29,13 +29,7 @@ export default async () => {
   const avansertDelmalHierarki: IMappe = hentMapper('avansertDelmal', mappestrukturDokumenter);
   const begrunnelseHierarki: IMappe = hentMapper('begrunnelse', mappestrukturDokumenter);
 
-  const { dataset } = client.config();
-
-  const erEf = dataset === 'ef-brev';
-
-  const ekskluderesForEf = ['dokument', 'periode'];
-
-  const avansertDokumentTittel = erEf ? 'Brevmaler' : 'Avansert dokument';
+  const avansertDokumentTittel = erEf() ? 'Brevmaler' : 'Avansert dokument';
 
   return S.list()
     .title('Content')

--- a/config/felles.ts
+++ b/config/felles.ts
@@ -1,0 +1,13 @@
+import client from 'part:@sanity/base/client';
+
+import { DokumentNavn } from '../src/util/typer';
+
+export const ekskluderesForEf: string[] = [
+  DokumentNavn.DELMAL,
+  DokumentNavn.DOKUMENT,
+  DokumentNavn.PERIODE,
+];
+
+const { dataset } = client.config();
+
+export const erEf = () => dataset === 'ef-brev';

--- a/config/newDocumentStructure.ts
+++ b/config/newDocumentStructure.ts
@@ -1,0 +1,8 @@
+import S from '@sanity/base/structure-builder';
+import { ekskluderesForEf, erEf } from './felles';
+
+export default [
+  ...S.defaultInitialValueTemplateItems().filter(
+    builder => !erEf() || !ekskluderesForEf.includes(builder.getId()),
+  ),
+];

--- a/sanity.json
+++ b/sanity.json
@@ -72,6 +72,10 @@
       "path": "./config/deskStructure.ts"
     },
     {
+      "name": "part:@sanity/base/new-document-structure",
+      "path": "./config/newDocumentStructure.ts"
+    },
+    {
       "implements": "part:@sanity/dashboard/config",
       "path": "./config/dashboardConfig.js"
     },

--- a/src/schemas/annonteringer/AvansertDelmalAnnontering.js
+++ b/src/schemas/annonteringer/AvansertDelmalAnnontering.js
@@ -1,14 +1,13 @@
 import styles from '../../../styles/myStyling.css';
 import React from 'react';
-import NyttFelt from '../../komponenter/NyttFelt';
 import { DokumentNavn, SanityTyper } from '../../util/typer';
 
 export const AvansertDelmalFelter = (erGjentagende = false) => [
   {
-    title: 'Delmal',
+    title: 'Avansert delmal',
     name: DokumentNavn.DELMAL_REFERANSE,
     type: SanityTyper.REFERENCE,
-    to: [{ type: 'avansertDelmal' }, { type: 'delmal' }],
+    to: { type: 'avansertDelmal' },
     validation: Rule => [Rule.required().error('Tom delmal')],
   },
   {
@@ -28,12 +27,6 @@ export const AvansertDelmalFelter = (erGjentagende = false) => [
         },
       ]
     : []),
-  {
-    name: 'lagNy',
-    type: 'string',
-    description: 'En knapp for å lage ny delmal',
-    inputComponent: props => NyttFelt(props, DokumentNavn.DELMAL),
-  },
 ];
 
 export default {

--- a/src/schemas/avansertDokument/avansertMalEditor.js
+++ b/src/schemas/avansertDokument/avansertMalEditor.js
@@ -1,6 +1,3 @@
-import FlettefeltAnnontering from '../annonteringer/FlettefeltAnnontering';
-import DelmalAnnontering from '../annonteringer/AvansertDelmalAnnontering';
-import ValgAnnontering from '../annonteringer/ValgAnnontering';
 import TekstStyles from '../../util/TekstStyles';
 import { SanityTyper } from '../../util/typer';
 import { avansertDelmalAvsnitt } from '../avsnitt/avansertDelmalAvsnitt';
@@ -22,7 +19,6 @@ export default (maalform, tittel) => ({
     {
       type: 'block',
       marks: {
-        annotations: [FlettefeltAnnontering(), DelmalAnnontering, ValgAnnontering],
         decorators,
       },
       styles: TekstStyles,

--- a/src/schemas/avsnitt/avansertDelmalAvsnitt.ts
+++ b/src/schemas/avsnitt/avansertDelmalAvsnitt.ts
@@ -3,7 +3,7 @@ import DelmalBlockComponent from '../../komponenter/DelmalBlockComponent';
 import { AvansertDelmalFelter } from '../annonteringer/AvansertDelmalAnnontering';
 
 export const avansertDelmalAvsnitt = maalform => ({
-  title: 'Delmal',
+  title: 'Avansert delmal',
   name: DokumentNavn.DELMAL_BLOCK,
   type: SanityTyper.OBJECT,
   fields: [...AvansertDelmalFelter(true)],


### PR DESCRIPTION
Vi vil unngå at EF-redaktører oppretter delmaler istedenfor avanserte delmaler. Fjerner derfor muligheten til å opprette det fra avansertDelmal-editoren og fra "Create new document"-modalen

**Avansert delmal editor**
Før:
![image](https://user-images.githubusercontent.com/21220467/183860592-9da7ab83-551a-4ff3-911d-104b9460aa59.png)

Etter:
![image](https://user-images.githubusercontent.com/21220467/183860405-f4d660d8-4d27-4a7f-b8cd-d0b280020ad5.png)

**Create new document modalen**
EF:
![image](https://user-images.githubusercontent.com/21220467/183860835-ecde512c-194d-4326-ac0c-88fe88db2481.png)
BA:
![image](https://user-images.githubusercontent.com/21220467/183860966-e642f89b-aeaa-47f1-88d5-d2508f1a133a.png)

