### PR TITLE
Fiks at begrunnesler-mappen forsvinner fra ba sine datasett

### DIFF
--- a/config/deskStructure.ts
+++ b/config/deskStructure.ts
@@ -2,7 +2,8 @@ import S from '@sanity/desk-tool/structure-builder';
 import { hentFraSanity } from '../src/util/sanity';
 import { GrDocumentText } from 'react-icons/gr';
 import { ListItemBuilder } from '@sanity/structure/lib/ListItem';
-import { ekskluderesForEf, erEf } from './felles';
+import { ekskluderesForBa, ekskluderesForEf, erBa, erEf } from './felles';
+import { BegrunnelseDokumentNavn, DokumentNavn } from '../src/util/typer';
 
 const DOKUMENTER = 'dokumenter';
 
@@ -29,31 +30,22 @@ export default async () => {
   const avansertDelmalHierarki: IMappe = hentMapper('avansertDelmal', mappestrukturDokumenter);
   const begrunnelseHierarki: IMappe = hentMapper('begrunnelse', mappestrukturDokumenter);
 
-  const avansertDokumentTittel = erEf() ? 'Brevmaler' : 'Avansert dokument';
+  const skalBrukeSanitySinStruktur = listItem =>
+    ![
+      BegrunnelseDokumentNavn.BEGRUNNELSE,
+      DokumentNavn.DELMAL,
+      DokumentNavn.AVANSERT_DELMAL,
+      ...(erEf() ? ekskluderesForEf : []),
+      ...(erBa() ? ekskluderesForBa : []),
+    ].includes(listItem.getId());
 
   return S.list()
     .title('Content')
     .items([
       hentDokumentMappe('delmal', delmalHierarki, 'Delmal'),
-      ...S.documentTypeListItems().filter(
-        listItem =>
-          ![
-            'delmal',
-            'avansertDelmal',
-            'begrunnelse',
-            'dokumentmal',
-            ...(erEf ? ekskluderesForEf : []),
-          ].includes(listItem.getId()),
-      ),
-      S.listItem()
-        .title(avansertDokumentTittel)
-        .child(S.documentTypeList('dokumentmal').title(avansertDokumentTittel).child()),
-      hentDokumentMappe(
-        'avansertDelmal',
-        avansertDelmalHierarki,
-        erEf ? 'Innhold' : 'Avansert delmal',
-      ),
-      ...(!erEf ? [hentDokumentMappe('begrunnelse', begrunnelseHierarki, 'Begrunnelse')] : []),
+      ...S.documentTypeListItems().filter(skalBrukeSanitySinStruktur),
+      ...(erEf() ? [hentDokumentMappe('avansertDelmal', avansertDelmalHierarki, 'Innhold')] : []),
+      ...(erBa() ? [hentDokumentMappe('begrunnelse', begrunnelseHierarki, 'Begrunnelse')] : []),
     ]);
 };
 

--- a/config/felles.ts
+++ b/config/felles.ts
@@ -1,13 +1,20 @@
 import client from 'part:@sanity/base/client';
 
-import { DokumentNavn } from '../src/util/typer';
+import { BegrunnelseDokumentNavn, DokumentNavn } from '../src/util/typer';
 
 export const ekskluderesForEf: string[] = [
   DokumentNavn.DELMAL,
   DokumentNavn.DOKUMENT,
   DokumentNavn.PERIODE,
+  BegrunnelseDokumentNavn.BEGRUNNELSE,
+];
+
+export const ekskluderesForBa: string[] = [
+  DokumentNavn.AVANSERT_DELMAL,
+  DokumentNavn.AVANSERT_DOKUMENT,
 ];
 
 const { dataset } = client.config();
 
-export const erEf = () => dataset === 'ef-brev';
+export const erEf = () => ['ef-brev', 'ef-test', 'testdata'].includes(dataset);
+export const erBa = () => ['ba-brev', 'ba-test', 'testdata'].includes(dataset);

--- a/src/schemas/avansertDokument/AvansertDelmal.js
+++ b/src/schemas/avansertDokument/AvansertDelmal.js
@@ -10,7 +10,7 @@ const TittelBadge = () => {
 };
 
 export default {
-  title: 'Avansert delmal',
+  title: 'Innhold',
   name: DokumentNavn.AVANSERT_DELMAL,
   type: SanityTyper.DOCUMENT,
   preview: {

--- a/src/schemas/avansertDokument/AvansertDokument.js
+++ b/src/schemas/avansertDokument/AvansertDokument.js
@@ -9,8 +9,8 @@ const TittelBadge = () => {
 };
 
 export default {
-  title: 'Avansert dokument',
-  name: DokumentNavn.DOKUMENTMAL,
+  title: 'Brevmaler',
+  name: DokumentNavn.AVANSERT_DOKUMENT,
   type: SanityTyper.DOCUMENT,
   preview: {
     select: {
@@ -66,7 +66,7 @@ export default {
       type: SanityTyper.STRING,
       name: DokumentNavn.API_NAVN,
       description: 'Teknisk navn. Eksempel innhenteOpplysninger',
-      validation: rule => apiNavnValideringer(rule, DokumentNavn.DOKUMENTMAL),
+      validation: rule => apiNavnValideringer(rule, DokumentNavn.AVANSERT_DOKUMENT),
     },
     { type: SanityTyper.STRING, title: 'Tittel bokmål', name: DokumentNavn.TITTEL_BOKMAAL },
     { type: SanityTyper.STRING, title: 'Tittel nynorsk', name: DokumentNavn.TITTEL_NYNORSK },

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -21,7 +21,7 @@ export enum DokumentNavn {
   DELMAL_BLOCK = 'delmalBlock',
   VALG_BLOCK = 'valgBlock',
   ER_GJENTAGENDE = 'erGjentagende',
-  DOKUMENTMAL = 'dokumentmal',
+  AVANSERT_DOKUMENT = 'dokumentmal',
   VALGFELT = 'valgfelt',
   ER_LISTE = 'erListe',
   ER_FRITEKSTFELT = 'erFritektsfelt',


### PR DESCRIPTION
Nå dukker alltid EF sin struktur opp for Ba. 
![image](https://user-images.githubusercontent.com/17828446/184347314-4e249c7c-4abe-4fb3-b8c8-88735517de6b.png)

Fikser dette og refaktorerer litt