### PR TITLE
Feature/vilkårtriggere på eøsbegrunnelser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,10 @@
       "jsx": true
     },
     "ecmaVersion": 2020,
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": [
+      "./tsconfig.json"
+    ]
   },
   "plugins": [
     "@typescript-eslint",
@@ -40,7 +43,8 @@
     "@typescript-eslint/no-var-requires": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",
     "react-app/react-hooks/exhaustive-deps": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "react": {

--- a/src/komponenter/DelmalBlockComponent.tsx
+++ b/src/komponenter/DelmalBlockComponent.tsx
@@ -7,7 +7,7 @@ const BlockContent = require('@sanity/block-content-to-react');
 
 const DelmalBlockComponent = (props: any, maalform: string, id = '', skalHaPadding = true) => {
   if (id) {
-    return DelmalBlock(props, maalform, id, false);
+    return DelmalBlock(props, maalform, id, skalHaPadding);
   } else {
     return <ErrorStyling>Fyll ut delmal.</ErrorStyling>;
   }

--- a/src/komponenter/DelmalBlockComponent.tsx
+++ b/src/komponenter/DelmalBlockComponent.tsx
@@ -6,13 +6,15 @@ import { Badge, Inline } from '@sanity/ui';
 const BlockContent = require('@sanity/block-content-to-react');
 
 const DelmalBlockComponent = (props: any, maalform: string, id = '', skalHaPadding = true) => {
-  const _id = id;
-
-  if (!_id) {
+  if (id) {
+    return DelmalBlock(props, maalform, id, false);
+  } else {
     return <ErrorStyling>Fyll ut delmal.</ErrorStyling>;
   }
+};
 
-  const query = `*[_id=="${_id}"]{..., ${maalform}[]{..., valgReferanse->}}`;
+const DelmalBlock = (props: any, maalform: string, id = '', skalHaPadding = true) => {
+  const query = `*[_id=="${id}"]{..., ${maalform}[]{..., valgReferanse->}}`;
   const { data, error } = useSanityQuery(query);
 
   if (error) {

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/annenForeldersAktivitetTrigger.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/annenForeldersAktivitetTrigger.ts
@@ -1,5 +1,6 @@
 import { EØSBegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { erEøsBegrunnelse, hentEØSTriggereRegler } from './utils';
+import { erEøsBegrunnelse, hentEØSTriggereRegler, kanKompetanseTriggereVelges } from './utils';
+import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
 
 enum AnnenForelderAktivitet {
   I_ARBEID = 'I_ARBEID',
@@ -38,6 +39,6 @@ export const annenForeldersAktivitetTrigger = {
       annenForelderAktivitet => annenForeldersAktivitetValg[annenForelderAktivitet],
     ),
   },
-  hidden: ({ document }) => !erEøsBegrunnelse(document),
-  validation: rule => hentEØSTriggereRegler(rule),
+  hidden: ({ document }) => !erEøsBegrunnelse(document) || !kanKompetanseTriggereVelges(document),
+  validation: rule => hentEØSTriggereRegler(rule, true, [EØSTriggerType.KOMPETANSE]),
 };

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/barnetsBostedslandTriggere.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/barnetsBostedslandTriggere.ts
@@ -1,5 +1,6 @@
 import { EØSBegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { erEøsBegrunnelse, hentEØSTriggereRegler } from './utils';
+import { erEøsBegrunnelse, hentEØSTriggereRegler, kanKompetanseTriggereVelges } from './utils';
+import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
 
 enum BarnetsBostedsland {
   NORGE = 'NORGE',
@@ -24,6 +25,6 @@ export const barnetsBosteslandTrigger = {
       barnetsBostedsland => BarnetsBostedslandValg[barnetsBostedsland],
     ),
   },
-  hidden: ({ document }) => !erEøsBegrunnelse(document),
-  validation: rule => hentEØSTriggereRegler(rule),
+  hidden: ({ document }) => !erEøsBegrunnelse(document) || !kanKompetanseTriggereVelges(document),
+  validation: rule => hentEØSTriggereRegler(rule, true, [EØSTriggerType.KOMPETANSE]),
 };

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/hvilkeTriggereSkalBrukes.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/hvilkeTriggereSkalBrukes.ts
@@ -1,0 +1,30 @@
+import { EØSBegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import { erEøsBegrunnelse, hentEØSTriggereRegler } from './utils';
+
+export enum EØSTriggerType {
+  KOMPETANSE = 'KOMPETANSE',
+  VILKÅRSVURDERING = 'VILKÅRSVURDERING',
+}
+
+const KompetanseValg: Record<EØSTriggerType, { title: string; value: EØSTriggerType }> = {
+  KOMPETANSE: {
+    title: 'Kompetanse',
+    value: EØSTriggerType.KOMPETANSE,
+  },
+  VILKÅRSVURDERING: {
+    title: 'Vilkårsvurdering',
+    value: EØSTriggerType.VILKÅRSVURDERING,
+  },
+};
+
+export const hvilkeTriggereSkalBrukes = {
+  title: 'Hvilke triggere skal brukes?',
+  type: SanityTyper.ARRAY,
+  name: EØSBegrunnelseDokumentNavn.TRIGGERE_I_BRUK,
+  of: [{ type: SanityTyper.STRING }],
+  options: {
+    list: Object.values(EØSTriggerType).map(eøsTrigger => KompetanseValg[eøsTrigger]),
+  },
+  hidden: ({ document }) => !erEøsBegrunnelse(document),
+  validation: rule => hentEØSTriggereRegler(rule, true, []),
+};

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/kompetentLandTrigger.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/kompetentLandTrigger.ts
@@ -1,5 +1,6 @@
 import { EØSBegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { erEøsBegrunnelse, hentEØSTriggereRegler } from './utils';
+import { erEøsBegrunnelse, hentEØSTriggereRegler, kanKompetanseTriggereVelges } from './utils';
+import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
 
 enum Kompetanse {
   NORGE_ER_PRIMÆRLAND = 'NORGE_ER_PRIMÆRLAND',
@@ -30,6 +31,6 @@ export const kompetentLandTrigger = {
   options: {
     list: Object.values(Kompetanse).map(kompetanse => KompetanseValg[kompetanse]),
   },
-  hidden: ({ document }) => !erEøsBegrunnelse(document),
-  validation: rule => hentEØSTriggereRegler(rule),
+  hidden: ({ document }) => !erEøsBegrunnelse(document) || !kanKompetanseTriggereVelges(document),
+  validation: rule => hentEØSTriggereRegler(rule, true, [EØSTriggerType.KOMPETANSE]),
 };

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utdypendeVilkårsvurderingerTriggere.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utdypendeVilkårsvurderingerTriggere.ts
@@ -1,0 +1,51 @@
+import { EØSBegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import {
+  erEøsBegrunnelse,
+  hentEØSTriggereRegler,
+  kanVilkårsvurderingTriggereVelges,
+} from './utils';
+import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
+
+enum UtdypendeVilkårsvurderingForEØS {
+  BARN_BOR_I_STORBRITANNIA = 'BARN_BOR_I_STORBRITANNIA',
+  BARN_BOR_I_STORBRITANNIA_MED_SØKER = 'BARN_BOR_I_STORBRITANNIA_MED_SØKER',
+  BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER = 'BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER',
+}
+
+const KompetanseValg: Record<
+  UtdypendeVilkårsvurderingForEØS,
+  { title: string; value: UtdypendeVilkårsvurderingForEØS }
+> = {
+  BARN_BOR_I_STORBRITANNIA: {
+    title: 'Barn bor i Storbritannia',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_STORBRITANNIA,
+  },
+  BARN_BOR_I_STORBRITANNIA_MED_SØKER: {
+    title: 'Barn bor i Storbritannia med søker',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_STORBRITANNIA_MED_SØKER,
+  },
+  BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER: {
+    title: 'Barn bor i Storbritannia med annen forelder',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER,
+  },
+};
+
+export const utdypendeVilkårsvurderingerForEØSTriggere = {
+  title: 'Utdypende vilkårsvurderinger',
+  type: SanityTyper.ARRAY,
+  name: EØSBegrunnelseDokumentNavn.UTDYPENDE_VILKÅRSVURDERINGER,
+  of: [
+    {
+      type: SanityTyper.STRING,
+    },
+  ],
+  options: {
+    list: Object.values(UtdypendeVilkårsvurderingForEØS).map(
+      utdypendeVilkårsvurderingForEøs => KompetanseValg[utdypendeVilkårsvurderingForEøs],
+    ),
+  },
+
+  hidden: ({ document }) =>
+    !erEøsBegrunnelse(document) || !kanVilkårsvurderingTriggereVelges(document),
+  validation: rule => hentEØSTriggereRegler(rule, false, [EØSTriggerType.VILKÅRSVURDERING]),
+};

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
@@ -21,7 +21,7 @@ export const kanKompetanseTriggereVelges = document =>
 
 export const hentEØSTriggereRegler = (
   rule,
-  obligatoriskOmSynlig: boolean,
+  erObligatoriskOmSynlig: boolean,
   regelTyper: EØSTriggerType[],
 ) => [
   hentEØSFeltRegler(
@@ -29,7 +29,7 @@ export const hentEØSTriggereRegler = (
     'en EØS-trigger er valgt, men behandlingstema for begrunnelsen er ikke EØS.',
   ),
   hentGyldigeTriggereRegel(rule, regelTyper),
-  obligatoriskOmSynlig && lagEØSFeltObligatoriskRegel(rule, regelTyper),
+  erObligatoriskOmSynlig && lagEØSFeltObligatoriskRegel(rule, regelTyper),
 ];
 
 export const hentEØSHjemmelRegler = rule =>

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
@@ -28,7 +28,6 @@ export const hentEØSTriggereRegler = (
     rule,
     'en EØS-trigger er valgt, men behandlingstema for begrunnelsen er ikke EØS.',
   ),
-  hentGyldigeTriggereRegel(rule, regelTyper),
   erObligatoriskOmSynlig && lagEØSFeltObligatoriskRegel(rule, regelTyper),
 ];
 
@@ -43,17 +42,6 @@ export const hentEØSFeltRegler = (rule, feilmelding: string) =>
     if (erNasjonalBegrunnelse(document) && currentValue !== undefined) {
       return feilmelding;
     }
-    return true;
-  });
-
-export const hentGyldigeTriggereRegel = (rule, triggerTyperforFelt: EØSTriggerType[]) =>
-  rule.custom((currentValue, { document }) => {
-    triggerTyperforFelt.forEach(triggerType => {
-      if (!kanTriggereAvTypeVelges(triggerType, document) && currentValue !== undefined) {
-        return `Det er ikke valgt at ${triggerType}-triggere kan velges, men en ${triggerType}-trigger er valgt`;
-      }
-    });
-
     return true;
   });
 

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
@@ -46,19 +46,16 @@ export const hentEØSFeltRegler = (rule, feilmelding: string) =>
     return true;
   });
 
-export const hentGyldigeTriggereRegel = (rule, triggerTyperforFelt: EØSTriggerType[]) => {
-  const lagFeilmelding = (avhengighet: string) =>
-    `Det er ikke valgt at ${avhengighet}-triggere kan velges, men en ${avhengighet}-trigger er valgt`;
-
-  return rule.custom((currentValue, { document }) => {
+export const hentGyldigeTriggereRegel = (rule, triggerTyperforFelt: EØSTriggerType[]) =>
+  rule.custom((currentValue, { document }) => {
     triggerTyperforFelt.forEach(triggerType => {
       if (!kanTriggereAvTypeVelges(triggerType, document) && currentValue !== undefined) {
-        return lagFeilmelding(triggerType);
+        return `Det er ikke valgt at ${triggerType}-triggere kan velges, men en ${triggerType}-trigger er valgt`;
       }
     });
+
     return true;
   });
-};
 
 const lagEØSFeltObligatoriskRegel = (rule, triggerTyperforFelt: EØSTriggerType[]) =>
   rule.custom((currentValue, { document }) => {

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/utils.ts
@@ -1,17 +1,35 @@
-import { BegrunnelseDokumentNavn } from '../../../../../util/typer';
+import { BegrunnelseDokumentNavn, EØSBegrunnelseDokumentNavn } from '../../../../../util/typer';
 import { Behandlingstema } from '../../typer';
 import { erNasjonalBegrunnelse } from '../../utils';
+import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
 
 export const erEøsBegrunnelse = document =>
   document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA] &&
   document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA].includes(Behandlingstema.EØS);
 
-export const hentEØSTriggereRegler = rule => [
+export const kanVilkårsvurderingTriggereVelges = document =>
+  document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA] &&
+  document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA].includes(Behandlingstema.EØS) &&
+  document[EØSBegrunnelseDokumentNavn.TRIGGERE_I_BRUK] &&
+  document[EØSBegrunnelseDokumentNavn.TRIGGERE_I_BRUK].includes(EØSTriggerType.VILKÅRSVURDERING);
+
+export const kanKompetanseTriggereVelges = document =>
+  document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA] &&
+  document[BegrunnelseDokumentNavn.BEHANDLINGSTEMA].includes(Behandlingstema.EØS) &&
+  document[EØSBegrunnelseDokumentNavn.TRIGGERE_I_BRUK] &&
+  document[EØSBegrunnelseDokumentNavn.TRIGGERE_I_BRUK].includes(EØSTriggerType.KOMPETANSE);
+
+export const hentEØSTriggereRegler = (
+  rule,
+  obligatoriskOmSynlig: boolean,
+  regelTyper: EØSTriggerType[],
+) => [
   hentEØSFeltRegler(
     rule,
     'en EØS-trigger er valgt, men behandlingstema for begrunnelsen er ikke EØS.',
   ),
-  lagEØSFeltObligatoriskRegel,
+  hentGyldigeTriggereRegel(rule, regelTyper),
+  obligatoriskOmSynlig && lagEØSFeltObligatoriskRegel(rule, regelTyper),
 ];
 
 export const hentEØSHjemmelRegler = rule =>
@@ -28,10 +46,43 @@ export const hentEØSFeltRegler = (rule, feilmelding: string) =>
     return true;
   });
 
-const lagEØSFeltObligatoriskRegel = rule =>
+export const hentGyldigeTriggereRegel = (rule, triggerTyperforFelt: EØSTriggerType[]) => {
+  const lagFeilmelding = (avhengighet: string) =>
+    `Det er ikke valgt at ${avhengighet}-triggere kan velges, men en ${avhengighet}-trigger er valgt`;
+
+  return rule.custom((currentValue, { document }) => {
+    triggerTyperforFelt.forEach(triggerType => {
+      if (!kanTriggereAvTypeVelges(triggerType, document) && currentValue !== undefined) {
+        return lagFeilmelding(triggerType);
+      }
+    });
+    return true;
+  });
+};
+
+const lagEØSFeltObligatoriskRegel = (rule, triggerTyperforFelt: EØSTriggerType[]) =>
   rule.custom((currentValue, { document }) => {
-    if (erEøsBegrunnelse(document) && currentValue === undefined) {
+    if (
+      erEøsBegrunnelse(document) &&
+      kanVelgeTriggerForEØSBegrunnesle(triggerTyperforFelt, document) &&
+      currentValue === undefined
+    ) {
       return 'Du må velge minst ett valg for triggerne';
     }
     return true;
   });
+
+const kanTriggereAvTypeVelges = (
+  triggerTyperforFelt: EØSTriggerType,
+  document: any,
+): ((document: any) => boolean) => {
+  switch (triggerTyperforFelt) {
+    case EØSTriggerType.VILKÅRSVURDERING:
+      return kanVilkårsvurderingTriggereVelges(document);
+    case EØSTriggerType.KOMPETANSE:
+      return kanKompetanseTriggereVelges(document);
+  }
+};
+
+const kanVelgeTriggerForEØSBegrunnesle = (triggerTyperForFelt: EØSTriggerType[], document: any) =>
+  triggerTyperForFelt.every(triggerType => kanTriggereAvTypeVelges(triggerType, document));

--- a/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/vilkårsvurderingerTriggere.ts
+++ b/src/schemas/ba-sak/begrunnelse/eøs/eøsTriggere/vilkårsvurderingerTriggere.ts
@@ -1,0 +1,43 @@
+import { EØSBegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import {
+  erEøsBegrunnelse,
+  hentEØSTriggereRegler,
+  kanVilkårsvurderingTriggereVelges,
+} from './utils';
+import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
+
+export enum Vilkår {
+  UNDER_18_ÅR = 'UNDER_18_ÅR',
+  BOR_MED_SØKER = 'BOR_MED_SØKER',
+  GIFT_PARTNERSKAP = 'GIFT_PARTNERSKAP',
+  BOSATT_I_RIKET = 'BOSATT_I_RIKET',
+  LOVLIG_OPPHOLD = 'LOVLIG_OPPHOLD',
+  UTVIDET_BARNETRYGD = 'UTVIDET_BARNETRYGD',
+}
+
+const vilkårValg: Record<Vilkår, { title: string; value: Vilkår }> = {
+  UNDER_18_ÅR: { title: 'Under 18 år', value: Vilkår.UNDER_18_ÅR },
+  BOR_MED_SØKER: { title: 'Bor med søker', value: Vilkår.BOR_MED_SØKER },
+  GIFT_PARTNERSKAP: { title: 'Gift partnerskap', value: Vilkår.GIFT_PARTNERSKAP },
+  BOSATT_I_RIKET: { title: 'Bosatt i riket', value: Vilkår.BOSATT_I_RIKET },
+  LOVLIG_OPPHOLD: { title: 'Lovlig opphold', value: Vilkår.LOVLIG_OPPHOLD },
+  UTVIDET_BARNETRYGD: { title: 'Utvidet barnetrygd', value: Vilkår.UTVIDET_BARNETRYGD },
+};
+
+export const vilkårsvurderingTriggere = {
+  title: 'Vilkår',
+  type: SanityTyper.ARRAY,
+  name: EØSBegrunnelseDokumentNavn.VILKÅR,
+  of: [
+    {
+      type: SanityTyper.STRING,
+    },
+  ],
+  options: {
+    list: Object.values(Vilkår).map(vilkår => vilkårValg[vilkår]),
+  },
+
+  hidden: ({ document }) =>
+    !erEøsBegrunnelse(document) || !kanVilkårsvurderingTriggereVelges(document),
+  validation: rule => hentEØSTriggereRegler(rule, true, [EØSTriggerType.VILKÅRSVURDERING]),
+};

--- a/src/schemas/ba-sak/begrunnelse/triggesAv.ts
+++ b/src/schemas/ba-sak/begrunnelse/triggesAv.ts
@@ -10,6 +10,9 @@ import { endretUtbetalingsperiodeDeltBostedUtbetalingTrigger } from './nasjonale
 import { annenForeldersAktivitetTrigger } from './eøs/eøsTriggere/annenForeldersAktivitetTrigger';
 import { barnetsBosteslandTrigger } from './eøs/eøsTriggere/barnetsBostedslandTriggere';
 import { kompetentLandTrigger } from './eøs/eøsTriggere/kompetentLandTrigger';
+import { utdypendeVilkårsvurderingerForEØSTriggere } from './eøs/eøsTriggere/utdypendeVilkårsvurderingerTriggere';
+import { hvilkeTriggereSkalBrukes } from './eøs/eøsTriggere/hvilkeTriggereSkalBrukes';
+import { vilkårsvurderingTriggere } from './eøs/eøsTriggere/vilkårsvurderingerTriggere';
 
 const nasjonaleBegrunnelserTriggere = [
   lovligOppholdTriggere,
@@ -24,9 +27,12 @@ const nasjonaleBegrunnelserTriggere = [
 ];
 
 const EØSBegrunnelseTriggere = [
+  hvilkeTriggereSkalBrukes,
   annenForeldersAktivitetTrigger,
   barnetsBosteslandTrigger,
   kompetentLandTrigger,
+  vilkårsvurderingTriggere,
+  utdypendeVilkårsvurderingerForEØSTriggere,
 ];
 
 export const triggesAv = [...nasjonaleBegrunnelserTriggere, ...EØSBegrunnelseTriggere];

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -79,4 +79,7 @@ export enum EØSBegrunnelseDokumentNavn {
   ANNEN_FORELDERS_AKTIVITET = 'annenForeldersAktivitet',
   BARNETS_BOSTEDSLAND = 'barnetsBostedsland',
   KOMPETANSE_RESULTAT = 'kompetanseResultat',
+  UTDYPENDE_VILKÅRSVURDERINGER = 'UtdypendeVilkaarsvurderinger',
+  TRIGGERE_I_BRUK = 'triggereIBruk',
+  VILKÅR = 'Vilkaar',
 }

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -81,5 +81,5 @@ export enum EØSBegrunnelseDokumentNavn {
   KOMPETANSE_RESULTAT = 'kompetanseResultat',
   UTDYPENDE_VILKÅRSVURDERINGER = 'utdypendeVilkaarsvurderinger',
   TRIGGERE_I_BRUK = 'triggereIBruk',
-  VILKÅR = 'vilkaar',
+  VILKÅR = 'eosVilkaar',
 }

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -79,7 +79,7 @@ export enum EØSBegrunnelseDokumentNavn {
   ANNEN_FORELDERS_AKTIVITET = 'annenForeldersAktivitet',
   BARNETS_BOSTEDSLAND = 'barnetsBostedsland',
   KOMPETANSE_RESULTAT = 'kompetanseResultat',
-  UTDYPENDE_VILKÅRSVURDERINGER = 'UtdypendeVilkaarsvurderinger',
+  UTDYPENDE_VILKÅRSVURDERINGER = 'utdypendeVilkaarsvurderinger',
   TRIGGERE_I_BRUK = 'triggereIBruk',
-  VILKÅR = 'Vilkaar',
+  VILKÅR = 'vilkaar',
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,13 @@
 {
-  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"],
+  "include": [
+    "./node_modules/@sanity/base/types/**/*.ts",
+    "./**/*.ts",
+    "./**/*.tsx",
+    "./config/*.js",
+    "./logo/*.js",
+    "./logo/*.js",
+    "./migreringer/*.js"
+  ],
   "compilerOptions": {
     "jsx": "react",
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9251

Eøs-opphør-begrunnelse nummer 5 skal bruke vilkår, og ikke kompetanse for å avgjøre om det skal trigges eller ikke. Legger derfor til vilkårtrigger og utdypendevilkårtrigger. I tillegg legger jeg til en mulighet for å avgjøre om det er kompetanser eller vilkår eller begge som skal vurderes når man ser om begrunnelsen skal brukes i en periode

Med kompetanse skrudd på:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/17828446/185341564-82125deb-53a7-4d08-a25b-124b8e2d6a2c.png">

Med vilkår skrudd på:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/17828446/185341265-1a6a3e15-209b-4ecc-aff6-c0570d3d1c4c.png">

Med begge skrudd på: 
<img width="416" alt="image" src="https://user-images.githubusercontent.com/17828446/185341442-604d7bee-3ce2-4838-9ee2-067581287ab9.png">

