### PR TITLE
Endre huskyscript til ren validering

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "start": "sanity start",
     "test": "sanity check",
     "start:server": "node ./src/server.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "eslint": "eslint './src/**/*.{js,ts,tsx}' --fix",
+    "prettier": "prettier --write"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css}": [
-      "prettier --write",
-      "eslint --fix ./"
+      "prettier --check",
+      "eslint"
     ]
   },
   "keywords": [


### PR DESCRIPTION
Samme endring som i ba-sak-frontend: https://github.com/navikt/familie-ba-sak-frontend/pull/2361

Vi har satt opp husky og lint-staged til å on-commit kjøre prettier og eslint **med skriving** i de filene som er lagt inn i commiten (*staged*):
- filen stages
- du kjører `git commit`
- prettier kjører på filen og skriver evt endringer
- eslint kjører på filen og skriver evt endringer
- filen stages på nytt, for å få med disse endringene
- commit fullføres
Det er helt supert dersom man commiter en hel fil av gangen. Men om man skal cherry-picke deler av en fil som skal stages stegvis vil prettier/eslint føre til at hele filen blir med i commiten. Dermed kan man ikke faktisk cherry-picke ☹️ 

Foreslår at vi endrer dette til at husky kun kjører **verifisering** med prettier og eslint, som feiler dersom noe er galt. Legger til npm-scripts som kjører prettier og eslint med skriving, altså det samme som husky har pleid å gjøre