### PR TITLE
Feltet BEGRUNNELSE_TYPE er endret tilbake til begrunnelsetype fra type

### DIFF
--- a/config/deskStructure.ts
+++ b/config/deskStructure.ts
@@ -3,7 +3,7 @@ import { hentFraSanity } from '../src/util/sanity';
 import { GrDocumentText } from 'react-icons/gr';
 import { ListItemBuilder } from '@sanity/structure/lib/ListItem';
 import { ekskluderesForBa, ekskluderesForEf, ekskluderesForKs, erBa, erEf, erKs } from './felles';
-import { BegrunnelseDokumentNavn, DokumentNavn } from '../src/util/typer';
+import {BegrunnelseDokumentNavn, DokumentNavn, KSBegrunnelseDokumentNavn} from '../src/util/typer';
 import ComposeIcon from 'part:@sanity/base/compose-icon';
 import { uuid } from '@sanity/uuid';
 import {resultatValg} from "../src/schemas/baks/begrunnelse/ks-sak/resultat";
@@ -59,7 +59,7 @@ export default async () => {
   const skalBrukeSanitySinStruktur = listItem =>
     ![
       BegrunnelseDokumentNavn.BA_BEGRUNNELSE,
-      BegrunnelseDokumentNavn.KS_BEGRUNNELSE,
+      KSBegrunnelseDokumentNavn.KS_BEGRUNNELSE,
       DokumentNavn.DELMAL,
       DokumentNavn.AVANSERT_DELMAL,
       ...(erEf() ? ekskluderesForEf : []),

--- a/config/felles.ts
+++ b/config/felles.ts
@@ -1,19 +1,19 @@
 import client from 'part:@sanity/base/client';
 
-import { BegrunnelseDokumentNavn, DokumentNavn } from '../src/util/typer';
+import {BegrunnelseDokumentNavn, DokumentNavn, KSBegrunnelseDokumentNavn} from '../src/util/typer';
 
 export const ekskluderesForEf: string[] = [
   DokumentNavn.DELMAL,
   DokumentNavn.DOKUMENT,
   DokumentNavn.PERIODE,
   BegrunnelseDokumentNavn.BA_BEGRUNNELSE,
-  BegrunnelseDokumentNavn.KS_BEGRUNNELSE,
+  KSBegrunnelseDokumentNavn.KS_BEGRUNNELSE,
 ];
 
 export const ekskluderesForBa: string[] = [
   DokumentNavn.AVANSERT_DELMAL,
   DokumentNavn.AVANSERT_DOKUMENT,
-  BegrunnelseDokumentNavn.KS_BEGRUNNELSE,
+  KSBegrunnelseDokumentNavn.KS_BEGRUNNELSE,
 ];
 
 export const ekskluderesForKs: string[] = [

--- a/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
@@ -1,4 +1,9 @@
-import { BegrunnelseDokumentNavn, DokumentNavn, SanityTyper } from '../../../../util/typer';
+import {
+  BegrunnelseDokumentNavn,
+  DokumentNavn,
+  KSBegrunnelseDokumentNavn,
+  SanityTyper,
+} from '../../../../util/typer';
 import { VilkårRolle } from '../ba-sak/typer';
 import { triggesAv } from './triggesAv';
 import { eøsHjemler } from '../ba-sak/eøs/hjemler';
@@ -10,11 +15,11 @@ import {
   begrunnelseFlettefelt,
   begrunnelseValgfelt,
 } from './begrunnelseFlettefelt';
-import { apiNavnValideringerBegrunnelse } from './valideringer';
 import { resultat } from './resultat';
 import { tema } from './tema';
 import { type } from './type';
 import { hjemler } from './hjemler';
+import { apiNavnValideringerBegrunnelse } from './valideringer';
 
 const editor = (maalform, tittel) => ({
   name: maalform,
@@ -31,7 +36,7 @@ const editor = (maalform, tittel) => ({
 
 const begrunnelse = {
   title: 'Begrunnelse',
-  name: BegrunnelseDokumentNavn.KS_BEGRUNNELSE,
+  name: KSBegrunnelseDokumentNavn.KS_BEGRUNNELSE,
   type: SanityTyper.DOCUMENT,
   preview: {
     select: {
@@ -55,7 +60,7 @@ const begrunnelse = {
       name: DokumentNavn.API_NAVN,
       description: 'Teknisk navn. Eksempel innvilgetInnhenteOpplysninger',
       validation: rule =>
-        apiNavnValideringerBegrunnelse(rule, BegrunnelseDokumentNavn.KS_BEGRUNNELSE),
+        apiNavnValideringerBegrunnelse(rule, KSBegrunnelseDokumentNavn.KS_BEGRUNNELSE),
     },
     {
       title: 'Navn i ks-sak',

--- a/src/schemas/baks/begrunnelse/ks-sak/resultat.ts
+++ b/src/schemas/baks/begrunnelse/ks-sak/resultat.ts
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
+import { KSBegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
 
 export enum Resultat {
   INNVILGET = 'INNVILGET',
@@ -22,7 +22,7 @@ export const resultatValg: Record<Resultat, { title: string; value: Resultat }> 
 export const resultat = {
   title: 'Resultat',
   type: SanityTyper.STRING,
-  name: BegrunnelseDokumentNavn.BEGRUNNELSE_RESULTAT,
+  name: KSBegrunnelseDokumentNavn.RESULTAT,
   options: {
     list: Object.values(Resultat).map(resultat => resultatValg[resultat]),
   },

--- a/src/schemas/baks/begrunnelse/ks-sak/tema.ts
+++ b/src/schemas/baks/begrunnelse/ks-sak/tema.ts
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
+import { KSBegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
 
 export enum Tema {
   NASJONAL = 'NASJONAL',
@@ -20,7 +20,7 @@ export const temaValg: Record<Tema, { title: string; value: Tema }> = {
 export const tema = {
   title: 'Tema',
   type: SanityTyper.STRING,
-  name: BegrunnelseDokumentNavn.BEGRUNNELSE_TEMA,
+  name: KSBegrunnelseDokumentNavn.TEMA,
   options: {
     list: Object.values(Tema).map(tema => temaValg[tema]),
   },

--- a/src/schemas/baks/begrunnelse/ks-sak/type.ts
+++ b/src/schemas/baks/begrunnelse/ks-sak/type.ts
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
+import { KSBegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
 
 export enum Type {
   STANDARD = 'STANDARD',
@@ -18,7 +18,7 @@ export const typeValg: Record<Type, { title: string; value: Type }> = {
 export const type = {
   title: 'Type',
   type: SanityTyper.STRING,
-  name: BegrunnelseDokumentNavn.BEGRUNNELSE_TYPE,
+  name: KSBegrunnelseDokumentNavn.TYPE,
   options: {
     list: Object.values(Type).map(type => typeValg[type]),
   },

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -53,7 +53,7 @@ export enum SanityTyper {
 export enum BegrunnelseDokumentNavn {
   BA_BEGRUNNELSE = 'begrunnelse',
   KS_BEGRUNNELSE = 'ksBegrunnelse',
-  BEGRUNNELSE_TYPE = 'type',
+  BEGRUNNELSE_TYPE = 'begrunnelsetype',
   BEGRUNNELSE_TEMA = 'tema',
   BEGRUNNELSE_RESULTAT = 'resultat',
   HJEMLER = 'hjemler',

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -52,10 +52,7 @@ export enum SanityTyper {
 
 export enum BegrunnelseDokumentNavn {
   BA_BEGRUNNELSE = 'begrunnelse',
-  KS_BEGRUNNELSE = 'ksBegrunnelse',
   BEGRUNNELSE_TYPE = 'begrunnelsetype',
-  BEGRUNNELSE_TEMA = 'tema',
-  BEGRUNNELSE_RESULTAT = 'resultat',
   HJEMLER = 'hjemler',
   HJEMLER_EØS_FORORDNINGEN_833 = 'hjemlerEOSForordningen883',
   HJEMLER_EØS_FORORDNINGEN_987 = 'hjemlerEOSForordningen987',
@@ -84,4 +81,11 @@ export enum EØSBegrunnelseDokumentNavn {
   UTDYPENDE_VILKÅRSVURDERINGER = 'utdypendeVilkaarsvurderinger',
   TRIGGERE_I_BRUK = 'triggereIBruk',
   VILKÅR = 'eosVilkaar',
+}
+
+export enum KSBegrunnelseDokumentNavn {
+  KS_BEGRUNNELSE = 'ksBegrunnelse',
+  RESULTAT = 'resultat',
+  TYPE = 'type',
+  TEMA = 'tema',
 }


### PR DESCRIPTION
Alle BA-begrunnelser fikk warnings på feltet `Begrunnelsetype` etter at navnet på feltet ble endret fra `begrunnelsetype` -> `type`.

Denne PR'en endrer navnet tilbake til `begrunnelsetype` slik at warnings forsvinner.

Tror jeg skal prøve å separere endringer på KSBegrunnelser litt bedre fremover 🙈 