### PR TITLE
Sikre at validering av nasj- og inst-vilkår ikke vises for andre behandlingstemaer

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
@@ -20,6 +20,7 @@ import {
   rolleSkalVises,
   validerFlettefeltErGyldigForBehandlingstema,
   erNasjonalEllerInstitusjonsBegrunnelse,
+  lagVilkårManglerForNasjonalEllerInstitusjonBegrunnelse,
 } from './utils';
 import { Mappe, mapperTilMenynavn } from './mapper';
 import { eøsHjemler } from './eøs/hjemler';
@@ -249,7 +250,7 @@ const begrunnelse = {
         list: vilkår,
       },
       validation: rule => [
-        rule.required().warning('Vilkår ikke valgt'),
+        lagVilkårManglerForNasjonalEllerInstitusjonBegrunnelse(rule).warning(),
         lagInvaliderUtvidetForInstitusjonRegel(rule),
       ],
       hidden: context => !erNasjonalEllerInstitusjonsBegrunnelse(context.document),

--- a/src/schemas/baks/begrunnelse/ba-sak/utils.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/utils.ts
@@ -45,3 +45,11 @@ export const lagUtfyltNasjonaltFeltMenFeilBehandlingstemaRegel = rule =>
     }
     return true;
   });
+
+export const lagVilkårManglerForNasjonalEllerInstitusjonBegrunnelse = rule =>
+  rule.custom((nåVerdi, context) => {
+    if (erNasjonalEllerInstitusjonsBegrunnelse(context.document) && nåVerdi === undefined) {
+      return 'Ingen vilkår er valgt';
+    }
+    return true;
+  });


### PR DESCRIPTION
I #314 gjorde jeg en omskriving av valideringen av vilkår for nasjonale- og institusjonstekster som viste seg å være for naiv. Advarselen dukket også opp for EØS-tekster. Retter dette ved å gjenopprette en tilsvarende valideringsfunksjon som før

**Før:**
![Screenshot 2022-11-17 at 14 14 16](https://user-images.githubusercontent.com/2379098/202456857-f9ecfada-4695-4d9b-aeea-e772fb5a5338.png)

**Etter:**
![Screenshot 2022-11-17 at 14 14 47](https://user-images.githubusercontent.com/2379098/202456993-2076dff3-ead8-4dcb-bc75-0e5b35cdbf62.png)
![Screenshot 2022-11-17 at 14 13 40](https://user-images.githubusercontent.com/2379098/202457006-76ab05ab-fa92-4591-85fc-3b71c3b7f1be.png)
