### PR TITLE
Lagt til feltet skalAlltidVises på ks-begrunnelse

### DIFF
--- a/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
@@ -106,6 +106,12 @@ const begrunnelse = {
       description:
         'Huk av dersom det skal dukke opp mulighet til å skrive inn fritekst når begrunnelsen er valgt i KS-SAK',
     },
+    {
+      title: 'Skal alltid vises',
+      type: SanityTyper.BOOLEAN,
+      name: KSBegrunnelseDokumentNavn.SKAL_ALLTID_VISES,
+      description: 'Huk av dersom begrunnelsen alltid skal dukke opp som et valg',
+    },
     vilkårsvurderingTriggere,
     utdypendeVilkårsvurderinger,
     triggere,

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -93,4 +93,5 @@ export enum KSBegrunnelseDokumentNavn {
   ENDRINGSAARSAKER = 'endringsaarsaker',
   ENDRET_UTBETALINGSPERIODE = 'endretUtbetalingsperiode',
   STØTTER_FRITEKST = 'stotterFritekst',
+  SKAL_ALLTID_VISES = 'skalAlltidVises',
 }


### PR DESCRIPTION
Det skal være mulig å styre at en begrunnelse alltid skal være tilgjengelig for saksbehandler. Feltet `skalAlltidVises` er derfor lagt til på ks-begrunnelse