### PR TITLE
Legg til felter for beskrivelse på valgfelt og flettefelt

### DIFF
--- a/src/schemas/felter/Flettefelt.ts
+++ b/src/schemas/felter/Flettefelt.ts
@@ -29,6 +29,12 @@ export default {
       type: SanityTyper.BOOLEAN,
     },
     {
+      title: 'Beskrivelse',
+      name: DokumentNavn.BESKRIVELSE,
+      type: SanityTyper.STRING,
+      description: 'Brukes av EF dersom det ønskes ekstra forklaring av feltet',
+    },
+    {
       name: 'hvorBrukesFlettefeltet',
       type: SanityTyper.STRING,
       description:

--- a/src/schemas/felter/Valgfelt.ts
+++ b/src/schemas/felter/Valgfelt.ts
@@ -20,6 +20,12 @@ export default {
       validation: rule => apiNavnValideringer(rule, DokumentNavn.VALGFELT),
     },
     {
+      title: 'Beskrivelse',
+      name: DokumentNavn.BESKRIVELSE,
+      type: SanityTyper.STRING,
+      description: 'Brukes av EF dersom det ønskes ekstra forklaring av feltet',
+    },
+    {
       name: 'hvorBrukesValgfeltet',
       type: SanityTyper.STRING,
       description:

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -38,6 +38,7 @@ export enum DokumentNavn {
   FOR_OVERGANGSSTØNAD = 'overgangsstonad',
   FOR_BARNETILSYN = 'barnetilsyn',
   FOR_SKOLEPENGER = 'skolepenger',
+  BESKRIVELSE = 'beskrivelse',
 }
 
 export enum SanityTyper {


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
I EF-sak har vi behov for å kunne legge til ekstra beskrivelse av valgfelter og flettefelt for å kunne forklare automatiske verdier og slippe lange titler med informasjon i parantes. 

### Hvordan påvirker dette andre?
Feltet vil kun hentes dersom det faktisk er en verdi å hente. Dvs. at om feltet ikke fylles inn i Sanity vil man heller ikke hente ut noe. (TLDR ingen påvirkning). 

Henger sammen med [PR 426](https://github.com/navikt/familie-brev/pull/426) i familie-brev

### Bilder
Kan endre plassering på feltet dersom det er ønskelig

<img width="911" alt="image" src="https://user-images.githubusercontent.com/46678893/221794546-b9dc6608-ca2f-4af2-bcee-aa3f0afa3041.png">
<img width="911" alt="image" src="https://user-images.githubusercontent.com/46678893/221794678-b13c2228-b4c9-4e7a-967c-a3a242623b2a.png">

For bilder av hvordan det brukes i EF-Sak se [PR 2134](https://github.com/navikt/familie-ef-sak-frontend/pull/2134)
