### PR TITLE
Skal kunne legge til fritekstområder i avansert dokument

### DIFF
--- a/src/komponenter/FritekstområdePreview.tsx
+++ b/src/komponenter/FritekstområdePreview.tsx
@@ -1,0 +1,12 @@
+import { Stack, Card, Flex, Text } from '@sanity/ui';
+import React from 'react';
+
+export const FritekstområdePreview: React.FC = () => (
+  <Stack>
+    <Card padding={3} tone={'caution'}>
+      <Flex justify="center">
+        <Text>Fritekstområde</Text>
+      </Flex>
+    </Card>
+  </Stack>
+);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,6 +16,7 @@ import Periode from './schemas/baks/periode';
 import BaBegrunnelse from './schemas/baks/begrunnelse/ba-sak/begrunnelse';
 import KsBegrunnelse from './schemas/baks/begrunnelse/ks-sak/begrunnelse';
 import Htmlfelt from './schemas/felter/Htmlfelt';
+import { Fritekstområde } from './schemas/avansertDokument/fritekstområde';
 
 sessionStorage.clear();
 
@@ -39,6 +40,7 @@ export default createSchema({
     KsBegrunnelse,
     AvansertDelmal,
     AvansertDokument,
+    Fritekstområde,
 
     // When added to this list, object types can be used as
     // { type: 'typename' } in other document schemas

--- a/src/schemas/avansertDokument/avansertMalEditor.js
+++ b/src/schemas/avansertDokument/avansertMalEditor.js
@@ -5,6 +5,8 @@ import { valgAvsnitt } from '../avsnitt/valgAvsnitt';
 import decorators from '../../util/decorators';
 import { htmlAvsnitt } from '../avsnitt/htmlAvsnitt';
 import FlettefeltAnnontering from '../annonteringer/FlettefeltAnnontering';
+import { Fritekstområde } from './fritekstområde';
+import React from 'react';
 
 export default (maalform, tittel) => ({
   name: maalform,
@@ -22,5 +24,6 @@ export default (maalform, tittel) => ({
       styles: TekstStyles,
     },
     htmlAvsnitt,
+    Fritekstområde,
   ],
 });

--- a/src/schemas/avansertDokument/fritekstområde.ts
+++ b/src/schemas/avansertDokument/fritekstområde.ts
@@ -1,0 +1,14 @@
+import { uuid } from '@sanity/uuid';
+import { FritekstområdePreview } from '../../komponenter/FritekstområdePreview';
+
+export const Fritekstområde = {
+  title: 'Fritekstområde',
+  name: 'fritekstområde',
+  type: 'object',
+  fields: [
+    { name: 'dummyfelt', type: 'string', initialValue: 'dummyverdi', readOnly: true, hidden: true }, // Brukes ikke til noen ting. Lagt til fordi sanity krever minst et felt
+  ],
+  preview: {
+    component: FritekstområdePreview,
+  },
+};


### PR DESCRIPTION
[Favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11847)

### Hvorfor er dette nødvendig? ✨
Vi ønsker å kunne legge til fritekstområder i avansert dokument (våre brevmaler) fordi det gjør det mulig å bruke tabell i fritekstbrev <3

### Hva er gjort? 🔥
Det er laget et nytt schema-object som heter "Fritekstområde". Dette er et placeholderobjekt som kan legges i avanserte dokumenter for å markere hvor ef-sak-frontend skal legge inn et fritekstområde. 

![image](https://user-images.githubusercontent.com/46678893/224024960-adbc8b8a-e715-4c36-b4f2-20ff72406a24.png)


### Hører sammen med 🤝

- [PR i familie-brev](https://github.com/navikt/familie-brev/pull/430)
- [PR i familie-ef-sak-frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/2165)