### PR TITLE
Endre fra record til funksjon. Fiks bruk av feil record i desk structure

### DIFF
--- a/config/deskStructure.ts
+++ b/config/deskStructure.ts
@@ -13,10 +13,18 @@ import { uuid } from '@sanity/uuid';
 import { resultatValg } from '../src/schemas/baks/begrunnelse/ks-sak/resultat';
 import { temaValg } from '../src/schemas/baks/begrunnelse/ks-sak/tema';
 import { typeValg } from '../src/schemas/baks/begrunnelse/ks-sak/type';
-import { begrunnelseTemaTilMenynavn } from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetema';
-import { valgbarhetTilMenynavn } from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/valgbarhet';
-import { begrunnelsestyperTilMenynavn } from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetype';
-import { vedtakResultatTilMenynavn } from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/vedtakResultat';
+import {
+  BegrunnelseTema,
+  begrunnelseTemaTilMenyValg,
+} from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetema';
+import {
+  Valgbarhet,
+  valgbarhetTilMenyValg,
+} from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/valgbarhet';
+import {
+  VedtakResultat,
+  vedtakResultatTilMenyValg,
+} from '../src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/vedtakResultat';
 
 interface IDokument {
   mappe?: string[] | null;
@@ -26,9 +34,9 @@ interface IDokument {
 }
 
 interface IBegrunnelse extends IDokument {
-  vedtakResultat?: string;
-  tema?: string;
-  valgbarhet?: string;
+  vedtakResultat?: VedtakResultat;
+  tema?: BegrunnelseTema;
+  valgbarhet?: Valgbarhet;
 }
 
 interface IKSBegrunnelse extends IDokument {
@@ -49,7 +57,7 @@ export default async () => {
     false,
   );
 
-  const begrunnelser: IKSBegrunnelse[] = await hentFraSanity(
+  const begrunnelser: IBegrunnelse[] = await hentFraSanity(
     '*[_type == "begrunnelse"]',
     false,
     false,
@@ -237,9 +245,9 @@ const hentMapperBaBegrunnelse = (type, begrunnelser: IBegrunnelse[]): IMappe => 
 
     const mappehierarkiForBegrunnelse: string[] = begrunnelseHarTemaOgTypeOgResultat
       ? [
-          begrunnelsestyperTilMenynavn[begrunnelse.vedtakResultat].title,
-          begrunnelseTemaTilMenynavn[begrunnelse.tema].title,
-          valgbarhetTilMenynavn[begrunnelse.valgbarhet].title,
+          vedtakResultatTilMenyValg(begrunnelse.vedtakResultat).title,
+          begrunnelseTemaTilMenyValg(begrunnelse.tema).title,
+          valgbarhetTilMenyValg(begrunnelse.valgbarhet).title,
         ]
       : [];
 

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetema.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetema.tsx
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
 
 export enum BegrunnelseTema {
   NASJONAL = 'NASJONAL',
@@ -6,16 +6,21 @@ export enum BegrunnelseTema {
   EØS = 'EØS',
 }
 
-export const begrunnelseTemaTilMenynavn: Record<
-  BegrunnelseTema,
-  {
-    title: string;
-    value: BegrunnelseTema;
-  }
-> = {
-  FELLES: { title: 'Felles', value: BegrunnelseTema.FELLES },
-  NASJONAL: { title: 'Nasjonal', value: BegrunnelseTema.NASJONAL },
-  EØS: { title: 'EØS', value: BegrunnelseTema.EØS },
+export const begrunnelseTemaTilMenyValg = (
+  begrunnelseTema: BegrunnelseTema,
+): Menyvalg<BegrunnelseTema> => {
+  const begrunnelseTemaTilMenynavn = (begrunnelseTema: BegrunnelseTema): string => {
+    switch (begrunnelseTema) {
+      case BegrunnelseTema.FELLES:
+        return 'Felles';
+      case BegrunnelseTema.NASJONAL:
+        return 'Nasjonal';
+      case BegrunnelseTema.EØS:
+        return 'EØS';
+    }
+  };
+
+  return { title: begrunnelseTemaTilMenynavn(begrunnelseTema), value: begrunnelseTema };
 };
 
 export const begrunnelseTema = {
@@ -23,8 +28,8 @@ export const begrunnelseTema = {
   type: SanityTyper.STRING,
   name: BegrunnelseDokumentNavn.TEMA,
   options: {
-    list: Object.values(BegrunnelseTema).map(
-      begrunnelseTema => begrunnelseTemaTilMenynavn[begrunnelseTema],
+    list: Object.values(BegrunnelseTema).map(begrunnelseTema =>
+      begrunnelseTemaTilMenyValg(begrunnelseTema),
     ),
   },
   validation: rule => rule.required().error('Behandlingstema ikke valgt'),

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetype.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/begrunnelsetype.tsx
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
 
 /**
  * @deprecated Skal bruke begrunnelseTema. Enn så lenge trenger vi denne for å vise riktige tiggere for endret utbetalingsperioder.
@@ -13,23 +13,29 @@ export enum Begrunnelsestype {
   ETTER_ENDRET_UTBETALINGSPERIODE = 'ETTER_ENDRET_UTBETALINGSPERIODE',
 }
 
-export const begrunnelsestyperTilMenynavn: Record<
-  Begrunnelsestype,
-  { title: string; value: Begrunnelsestype }
-> = {
-  INNVILGET: { title: 'Innvilget', value: Begrunnelsestype.INNVILGET },
-  REDUKSJON: { title: 'Reduksjon', value: Begrunnelsestype.REDUKSJON },
-  AVSLAG: { title: 'Avslag', value: Begrunnelsestype.AVSLAG },
-  OPPHØR: { title: 'Opphør', value: Begrunnelsestype.OPPHØR },
-  FORTSATT_INNVILGET: { title: 'Fortsatt innvilget', value: Begrunnelsestype.FORTSATT_INNVILGET },
-  ENDRET_UTBETALINGSPERIODE: {
-    title: 'Endret utbetaling',
-    value: Begrunnelsestype.ENDRET_UTBETALINGSPERIODE,
-  },
-  ETTER_ENDRET_UTBETALINGSPERIODE: {
-    title: 'Etter endret utbetaling',
-    value: Begrunnelsestype.ETTER_ENDRET_UTBETALINGSPERIODE,
-  },
+export const begrunnelsestyperTilMenyValg = (
+  begrunnelsestype: Begrunnelsestype,
+): Menyvalg<Begrunnelsestype> => {
+  const begrunnelsestypeTilMenynavn = (begrunnelsestype: Begrunnelsestype): string => {
+    switch (begrunnelsestype) {
+      case Begrunnelsestype.INNVILGET:
+        return 'Innvilget';
+      case Begrunnelsestype.REDUKSJON:
+        return 'Reduksjon';
+      case Begrunnelsestype.AVSLAG:
+        return 'Avslag';
+      case Begrunnelsestype.OPPHØR:
+        return 'Opphør';
+      case Begrunnelsestype.FORTSATT_INNVILGET:
+        return 'Fortsatt innvilget';
+      case Begrunnelsestype.ENDRET_UTBETALINGSPERIODE:
+        return 'Endret utbetaling';
+      case Begrunnelsestype.ETTER_ENDRET_UTBETALINGSPERIODE:
+        return 'Etter endret utbetaling';
+    }
+  };
+
+  return { title: begrunnelsestypeTilMenynavn(begrunnelsestype), value: begrunnelsestype };
 };
 
 /**
@@ -40,8 +46,8 @@ export const begunnelseType = {
   type: SanityTyper.STRING,
   name: BegrunnelseDokumentNavn.BEGRUNNELSE_TYPE,
   options: {
-    list: Object.values(Begrunnelsestype).map(
-      begrunnelsestype => begrunnelsestyperTilMenynavn[begrunnelsestype],
+    list: Object.values(Begrunnelsestype).map(begrunnelsestype =>
+      begrunnelsestyperTilMenyValg(begrunnelsestype),
     ),
   },
   validation: rule => rule.required().error('Begrunnelsestype ikke valgt'),

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/fagsakType.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/fagsakType.tsx
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
 import { Begrunnelse } from '../typer';
 import { erSakspesifikkBegrunnelse } from './valgbarhet';
 
@@ -8,16 +8,19 @@ export enum FagsakType {
   ENSLIG_MINDREÅRIG = 'ENSLIG_MINDREÅRIG',
 }
 
-export const fagsaktypeTilMenynavn: Record<
-  FagsakType,
-  {
-    title: string;
-    value: FagsakType;
-  }
-> = {
-  STANDARD: { title: 'Standard', value: FagsakType.STANDARD },
-  INSTITUSJON: { title: 'Institusjon', value: FagsakType.INSTITUSJON },
-  ENSLIG_MINDREÅRIG: { title: 'Enslig mindreårig', value: FagsakType.ENSLIG_MINDREÅRIG },
+export const fagsaktypeTilMenyValg = (fagsaktype: FagsakType): Menyvalg<FagsakType> => {
+  const fagsaktypeTilMenynavn = (fagsaktype: FagsakType): string => {
+    switch (fagsaktype) {
+      case FagsakType.STANDARD:
+        return 'Standard';
+      case FagsakType.INSTITUSJON:
+        return 'Institusjon';
+      case FagsakType.ENSLIG_MINDREÅRIG:
+        return 'Enslig mindreårig';
+    }
+  };
+
+  return { title: fagsaktypeTilMenynavn(fagsaktype), value: fagsaktype };
 };
 
 export const fagsakType = {
@@ -25,7 +28,7 @@ export const fagsakType = {
   type: SanityTyper.STRING,
   name: BegrunnelseDokumentNavn.FAGSAK_TYPE,
   options: {
-    list: Object.values(FagsakType).map(valgbarhet => fagsaktypeTilMenynavn[valgbarhet]),
+    list: Object.values(FagsakType).map(valgbarhet => fagsaktypeTilMenyValg(valgbarhet)),
   },
   hidden: context => !erSakspesifikkBegrunnelse(context.document),
   validation: rule => [erFagsakspesifikkRegel(rule)],

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/valgbarhet.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/valgbarhet.tsx
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
 import { Begrunnelse } from '../typer';
 
 export enum Valgbarhet {
@@ -12,17 +12,21 @@ export const erSakspesifikkBegrunnelse = (begrunnelse: Begrunnelse) =>
   begrunnelse[BegrunnelseDokumentNavn.VALGBARHET] &&
   begrunnelse[BegrunnelseDokumentNavn.VALGBARHET] === Valgbarhet.SAKSPESIFIKK;
 
-export const valgbarhetTilMenynavn: Record<
-  Valgbarhet,
-  {
-    title: string;
-    value: Valgbarhet;
-  }
-> = {
-  AUTOMATISK: { title: 'Automatisk', value: Valgbarhet.AUTOMATISK },
-  STANDARD: { title: 'Standard', value: Valgbarhet.STANDARD },
-  TILLEGGSTEKST: { title: 'Tilleggstekst', value: Valgbarhet.TILLEGGSTEKST },
-  SAKSPESIFIKK: { title: 'Sakspesifikk', value: Valgbarhet.SAKSPESIFIKK },
+export const valgbarhetTilMenyValg = (valgbarhet: Valgbarhet): Menyvalg<Valgbarhet> => {
+  const valgbarhetTilMenynavn = (valgbarhet: Valgbarhet): string => {
+    switch (valgbarhet) {
+      case Valgbarhet.AUTOMATISK:
+        return 'Automatisk';
+      case Valgbarhet.STANDARD:
+        return 'Standard';
+      case Valgbarhet.TILLEGGSTEKST:
+        return 'Tilleggstekst';
+      case Valgbarhet.SAKSPESIFIKK:
+        return 'Sakspesifikk';
+    }
+  };
+
+  return { title: valgbarhetTilMenynavn(valgbarhet), value: valgbarhet };
 };
 
 export const valgbarhet = {
@@ -30,7 +34,7 @@ export const valgbarhet = {
   type: SanityTyper.STRING,
   name: BegrunnelseDokumentNavn.VALGBARHET,
   options: {
-    list: Object.values(Valgbarhet).map(valgbarhet => valgbarhetTilMenynavn[valgbarhet]),
+    list: Object.values(Valgbarhet).map(valgbarhet => valgbarhetTilMenyValg(valgbarhet)),
   },
   validation: rule => rule.required().error('Valgbarhet ikke satt'),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/vedtakResultat.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/vedtakResultat.tsx
@@ -1,4 +1,4 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
+import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
 
 export enum VedtakResultat {
   INNVILGET_ELLER_ØKNING = 'INNVILGET_ELLER_ØKNING',
@@ -7,20 +7,23 @@ export enum VedtakResultat {
   INGEN_ENDRING = 'INGEN_ENDRING',
 }
 
-export const vedtakResultatTilMenynavn: Record<
-  VedtakResultat,
-  {
-    title: string;
-    value: VedtakResultat;
-  }
-> = {
-  INNVILGET_ELLER_ØKNING: {
-    title: 'Innvilget eller økning',
-    value: VedtakResultat.INNVILGET_ELLER_ØKNING,
-  },
-  REDUKSJON: { title: 'Reduksjon', value: VedtakResultat.REDUKSJON },
-  IKKE_INNVILGET: { title: 'Ikke innvilget', value: VedtakResultat.IKKE_INNVILGET },
-  INGEN_ENDRING: { title: 'Ingen endring', value: VedtakResultat.INGEN_ENDRING },
+export const vedtakResultatTilMenyValg = (
+  vedtakResultat: VedtakResultat,
+): Menyvalg<VedtakResultat> => {
+  const vedtakResultatTilMenynavn = (vedtakResultat: VedtakResultat): string => {
+    switch (vedtakResultat) {
+      case VedtakResultat.INNVILGET_ELLER_ØKNING:
+        return 'Innvilget eller økning';
+      case VedtakResultat.REDUKSJON:
+        return 'Reduksjon';
+      case VedtakResultat.INGEN_ENDRING:
+        return 'Ingen endring';
+      case VedtakResultat.IKKE_INNVILGET:
+        return 'Ikke innvilget';
+    }
+  };
+
+  return { title: vedtakResultatTilMenynavn(vedtakResultat), value: vedtakResultat };
 };
 
 export const vedtakResultat = {
@@ -28,8 +31,8 @@ export const vedtakResultat = {
   type: SanityTyper.STRING,
   name: BegrunnelseDokumentNavn.VEDTAK_RESULTAT,
   options: {
-    list: Object.values(VedtakResultat).map(
-      vedtakResultat => vedtakResultatTilMenynavn[vedtakResultat],
+    list: Object.values(VedtakResultat).map(vedtakResultat =>
+      vedtakResultatTilMenyValg(vedtakResultat),
     ),
   },
   validation: rule => rule.required().error('VedtakResultat ikke valgt'),

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -1,3 +1,5 @@
+import { Valgbarhet } from '../schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/valgbarhet';
+
 export enum DokumentNavn {
   DOKUMENT = 'dokument',
   TITTEL_BOKMAAL = 'tittelBokmaal',
@@ -99,4 +101,9 @@ export enum KSBegrunnelseDokumentNavn {
   ENDRET_UTBETALINGSPERIODE = 'endretUtbetalingsperiode',
   STØTTER_FRITEKST = 'stotterFritekst',
   SKAL_ALLTID_VISES = 'skalAlltidVises',
+}
+
+export interface Menyvalg<T> {
+  title: string;
+  value: T;
 }


### PR DESCRIPTION
Vi har ikke typesikring på nøklene til en record
![Skjermbilde 2023-06-01 kl  10 23 09](https://github.com/navikt/familie-sanity-brev/assets/17828446/537f797a-deb0-49be-bba0-c2ecdf25c791)

Endrer derfor konverteringen av enum til menynavn fra record til funksjoner

Kan skryte av chatGPT her. Denne prompten gjorde det veldig enkelt å gjøre endringen 🙌 

```
I have an old format:
export const begrunnelseTemaTilMenynavn: Record<
  BegrunnelseTema,
  {
    title: string;
    value: BegrunnelseTema;
  }
> = {
  FELLES: { title: 'Felles', value: BegrunnelseTema.FELLES },
  NASJONAL: { title: 'Nasjonal', value: BegrunnelseTema.NASJONAL },
  EØS: { title: 'EØS', value: BegrunnelseTema.EØS },
};

And a new format:
export const begrunnelseTemaTilMenyValg = (
  begrunnelseTema: BegrunnelseTema,
): Menyvalg<BegrunnelseTema> => {
  const begrunnelseTemaTilMenynavn = (begrunnelseTema: BegrunnelseTema): string => {
    switch (begrunnelseTema) {
      case BegrunnelseTema.FELLES:
        return 'Felles';
      case BegrunnelseTema.NASJONAL:
        return 'Nasjonal';
      case BegrunnelseTema.EØS:
        return 'EØS';
    }
  };

  return { title: begrunnelseTemaTilMenynavn(begrunnelseTema), value: begrunnelseTema };
};

I will give you an element in the old format and you will reply with an element in the new format. Is that understood?
```
