### PR TITLE
Gjør det mulig å ikke velge fagsakspesifikk type. Vis nasjonale triggere når tema er felles

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/utils.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/utils.ts
@@ -4,7 +4,8 @@ import { BegrunnelseTema } from '../sanityMappeFelt/begrunnelsetema';
 
 export const erNasjonalBegrunnelse = (document: Begrunnelse): document is NasjonalBegrunnelse =>
   document[BegrunnelseDokumentNavn.TEMA] &&
-  document[BegrunnelseDokumentNavn.TEMA] === BegrunnelseTema.NASJONAL;
+  (document[BegrunnelseDokumentNavn.TEMA] === BegrunnelseTema.NASJONAL ||
+    document[BegrunnelseDokumentNavn.TEMA] === BegrunnelseTema.FELLES);
 
 export const hentNasjonaltFeltRegler = (rule, feilmelding: string) =>
   rule.custom((currentValue, { document }) => {

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/fagsakType.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/fagsakType.tsx
@@ -37,10 +37,10 @@ export const fagsakType = {
 export const erFagsakspesifikkRegel = rule =>
   rule.custom((nåVerdi, context) => {
     const begrunnelse: Begrunnelse = context.document;
+    const feltErSattMenErIkkeSakspesifikkBegrunnelse =
+      !erSakspesifikkBegrunnelse(begrunnelse) && nåVerdi;
 
-    if (erSakspesifikkBegrunnelse(begrunnelse)) {
-      return nåVerdi ? true : 'Må velge fagsaktype når valgbarhet er satt til "sakspesifikk"';
-    } else {
-      return nåVerdi ? 'Kan kun velge fagsaktype når valgbarhet er satt til "sakspesifikk"' : true;
-    }
+    return feltErSattMenErIkkeSakspesifikkBegrunnelse
+      ? 'Kan kun velge fagsaktype når valgbarhet er satt til "sakspesifikk"'
+      : true;
   });


### PR DESCRIPTION
Når valgbarhet er saksbesifikk ønsker vi å ikke velge noe for fagsakType for utvidet barnetrygd-begrunnelsene. 

Vi må kunne se vilkårstriggerene for utvidet barnetrygd som går under tema felles