### PR TITLE
Fiks. Skal bruke navlogo ved SSO

### DIFF
--- a/config/@sanity/default-login.json
+++ b/config/@sanity/default-login.json
@@ -7,7 +7,7 @@
         "name": "saml",
         "title": "NAV SSO",
         "url": "https://api.sanity.io/v2021-10-01/auth/saml/login/f3270b37",
-        "logo": "/static/navlogo.png"
+        "logo": "/static/navlogo.svg"
       }
     ]
   }


### PR DESCRIPTION
NAV logoen vises ikke riktig ved innlogging med SSO fordi den henviser til en png istedenfor svg.

![image](https://github.com/navikt/familie-sanity-brev/assets/21220467/cf746728-56fc-4771-945b-c98cdf8f3d35)
