### PR TITLE
Skal kunne velge at en mal er frittstående, og anngi tittel i dokumentoversikt

### DIFF
--- a/src/schemas/avansertDokument/AvansertDokument.js
+++ b/src/schemas/avansertDokument/AvansertDokument.js
@@ -56,6 +56,39 @@ export default {
       type: SanityTyper.BOOLEAN,
     },
     {
+      title: 'Frittstående brev',
+      name: DokumentNavn.FRITTSTÅENDE_BREV,
+      type: SanityTyper.OBJECT,
+      fields: [
+        {
+          title: 'Kan brukes frittstående',
+          name: DokumentNavn.VALGT_SOM_FRITTSTÅENDE_BREV,
+          description:
+            'Når denne avhukes vil malen vises for frittsående brev. En mal kan brukes både frittstående og i behandlinsgflyt',
+          type: SanityTyper.BOOLEAN,
+        },
+        {
+          title: 'Tittel Dokumentoversikt',
+          name: DokumentNavn.TITTEL_DOKUMENTOVERSIKT,
+          description:
+            'Tittel på brev i dokumentoversikten. Er kun gjeldende for frittstående brev',
+          type: SanityTyper.STRING,
+          validation: Rule =>
+            Rule.custom((tittel, context) => {
+              if (
+                context.document[DokumentNavn.FRITTSTÅENDE_BREV][
+                  DokumentNavn.VALGT_SOM_FRITTSTÅENDE_BREV
+                ] &&
+                (!tittel || tittel.length < 3)
+              ) {
+                return "Tittel i dokumentoversikt er påkrevd når 'Frittstående brev' er valgt";
+              }
+              return true;
+            }),
+        },
+      ],
+    },
+    {
       title: 'Visningsnavn',
       type: SanityTyper.STRING,
       name: DokumentNavn.VISNINGSNAVN,

--- a/src/schemas/avansertDokument/AvansertDokument.js
+++ b/src/schemas/avansertDokument/AvansertDokument.js
@@ -62,7 +62,7 @@ export default {
       fields: [
         {
           title: 'Kan brukes frittstående',
-          name: DokumentNavn.VALGT_SOM_FRITTSTÅENDE_BREV,
+          name: DokumentNavn.FOR_FRITTSTÅENDE_BREV,
           description:
             'Når denne avhukes vil malen vises for frittsående brev. En mal kan brukes både frittstående og i behandlinsgflyt',
           type: SanityTyper.BOOLEAN,
@@ -77,7 +77,7 @@ export default {
             Rule.custom((tittel, context) => {
               if (
                 context.document[DokumentNavn.FRITTSTÅENDE_BREV][
-                  DokumentNavn.VALGT_SOM_FRITTSTÅENDE_BREV
+                  DokumentNavn.FOR_FRITTSTÅENDE_BREV
                 ] &&
                 (!tittel || tittel.length < 3)
               ) {

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -42,7 +42,7 @@ export enum DokumentNavn {
   FOR_SKOLEPENGER = 'skolepenger',
   BESKRIVELSE = 'beskrivelse',
   FRITTSTÅENDE_BREV = 'frittstaendeBrev',
-  VALGT_SOM_FRITTSTÅENDE_BREV = 'valgtSomFrittstaendeBrev',
+  FOR_FRITTSTÅENDE_BREV = 'valgtSomFrittstaendeBrev',
   TITTEL_DOKUMENTOVERSIKT = 'tittelDokumentoversikt',
 }
 

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -41,6 +41,9 @@ export enum DokumentNavn {
   FOR_BARNETILSYN = 'barnetilsyn',
   FOR_SKOLEPENGER = 'skolepenger',
   BESKRIVELSE = 'beskrivelse',
+  FRITTSTÅENDE_BREV = 'frittstaendeBrev',
+  VALGT_SOM_FRITTSTÅENDE_BREV = 'valgtSomFrittstaendeBrev',
+  TITTEL_DOKUMENTOVERSIKT = 'tittelDokumentoversikt',
 }
 
 export enum SanityTyper {


### PR DESCRIPTION
**Hvorfor?**
[Vi skal ta i bruk sanity for frittstående brev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119), men det er ikke alle malene som skal kunne brukes som frittstående. Legger derfor til et felt for å markere om malen skal kunne brukes frittstående. For frittstående brev trenger vi også en dokumenttittel for bruk ved journalføring, som vil vises i dokumentoversikten.

**Screenshot**
![image](https://github.com/navikt/familie-sanity-brev/assets/21220467/c87e829f-ef88-4b27-9b0d-be9c711a5a00)
