### PR TITLE
Sorter KS-begrunnelser etter visningsnavn

### DIFF
--- a/config/deskStructure.ts
+++ b/config/deskStructure.ts
@@ -164,7 +164,7 @@ const hentDokumentMappe = (
 };
 
 const sorterBegrunnelseDokumenter = (dokumenter: IDokument[], type): IDokument[] => {
-  if (type === 'begrunnelse') {
+  if (type === 'begrunnelse' || type === 'ksBegrunnelse') {
     return dokumenter.sort((a, b) =>
       a?.visningsnavn && b?.visningsnavn
         ? hentFørsteTallIStartAvTekst(a.visningsnavn) - hentFørsteTallIStartAvTekst(b.visningsnavn)


### PR DESCRIPTION
Favro: NAV-13592
Inkluder typen til ks-begrunnelser når vi vurderer om begrunnelsesdokumenter skal sorteres etter visningsnavn

Før:
<img width="411" alt="image" src="https://github.com/navikt/familie-sanity-brev/assets/2379098/48e9e6cc-9d31-4edf-b310-a10a1898dc7b">
Etter:
<img width="409" alt="image" src="https://github.com/navikt/familie-sanity-brev/assets/2379098/7955c29a-f9fe-4a46-807c-770a5ec55d17">
