### PR TITLE
Omdøp triggere for opphør og redukson  på tvers av behandling

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -123,11 +123,11 @@ export const vilkårTriggerTilMenynavn: Record<VilkårTriggere, { title: string;
     value: VilkårTriggere.SMÅBARNSTILLEGG,
   },
   GJELDER_FØRSTE_PERIODE: {
-    title: 'Gjelder første periode',
+    title: 'Opphør fra forrige behandling',
     value: VilkårTriggere.GJELDER_FØRSTE_PERIODE,
   },
   GJELDER_FRA_INNVILGELSESTIDSPUNKT: {
-    title: 'Gjelder fra invilgelsestidspunkt',
+    title: 'Reduksjon fra forrige behandling',
     value: VilkårTriggere.GJELDER_FRA_INNVILGELSESTIDSPUNKT,
   },
   BARN_DØD: {


### PR DESCRIPTION
Favro: NAV-13722

Vi omdøper disse triggerne for å samsvare bedre med hvordan de brukes funksjonelt.
Endrer ikke selve enumen og databaseverdien denne gangen - men har laget teknisk gjeld-kort på det: NAV-15256