### PR TITLE
Fiks visningsnavn på valgfelter og flettefelter

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
@@ -113,9 +113,7 @@ const begrunnelseValgfelt = {
   },
   components: {
     preview: (props: any) => (
-      <Flettefelt>
-        {props.value?.valgVisningsnavn ? props.value.valgVisningsnavn : 'Tomt valgfelt'}
-      </Flettefelt>
+      <Flettefelt>{props?.valgVisningsnavn ? props.valgVisningsnavn : 'Tomt valgfelt'}</Flettefelt>
     ),
   },
 };

--- a/src/schemas/baks/begrunnelse/ks-sak/begrunnelseFlettefelt.tsx
+++ b/src/schemas/baks/begrunnelse/ks-sak/begrunnelseFlettefelt.tsx
@@ -29,9 +29,7 @@ export const begrunnelseFlettefelt = {
   },
   components: {
     preview: (props: any) => {
-      const flettefelt = flettefelter.find(
-        flettefelt => flettefelt.value === props.value.flettefelt,
-      );
+      const flettefelt = flettefelter.find(flettefelt => flettefelt.value === props.flettefelt);
       return <Flettefelt>{flettefelt?.title ?? 'Tomt flettefelt'}</Flettefelt>;
     },
   },
@@ -61,9 +59,7 @@ export const begrunnelseEØSFlettefelt = {
   },
   components: {
     preview: (props: any) => {
-      const flettefelt = eøsFlettefelter.find(
-        flettefelt => flettefelt.value === props.value.flettefelt,
-      );
+      const flettefelt = eøsFlettefelter.find(flettefelt => flettefelt.value === props.flettefelt);
       return <Flettefelt>{flettefelt?.title ?? 'Tomt flettefelt'}</Flettefelt>;
     },
   },
@@ -96,9 +92,7 @@ export const begrunnelseValgfelt = {
   },
   components: {
     preview: (props: any) => (
-      <Flettefelt>
-        {props.value?.valgVisningsnavn ? props.value.valgVisningsnavn : 'Tomt valgfelt'}
-      </Flettefelt>
+      <Flettefelt>{props?.valgVisningsnavn ? props.valgVisningsnavn : 'Tomt valgfelt'}</Flettefelt>
     ),
   },
 };


### PR DESCRIPTION
Hvordan vi henter ut data fra objekter i sanity ble endret fra v2 til v3 og ikke alle endringene kom med. Fikser navn på flettefelt og valgfelt. 

Ref feil [nevnt på slack](https://nav-it.slack.com/archives/D01EL9GH5PA/p1693993316653289)