### PR TITLE
Lagt til manglende valg blandt annen forelders aktiviteter (EØS-Praksisendring)

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/eøs/eøsTriggere/annenForeldersAktivitetTrigger.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/eøs/eøsTriggere/annenForeldersAktivitetTrigger.ts
@@ -10,6 +10,19 @@ enum AnnenForelderAktivitet {
   INAKTIV = 'INAKTIV',
   IKKE_AKTUELT = 'IKKE_AKTUELT',
   UTSENDT_ARBEIDSTAKER = 'UTSENDT_ARBEIDSTAKER',
+
+  // Annen forelders aktivitet valg som kun gjelder dersom annen forelder er omfattet av norsk lovgivning
+  ARBEIDER = 'ARBEIDER',
+  SELVSTENDIG_NÆRINGSDRIVENDE = 'SELVSTENDIG_NÆRINGSDRIVENDE',
+  UTSENDT_ARBEIDSTAKER_FRA_NORGE = 'UTSENDT_ARBEIDSTAKER_FRA_NORGE',
+  MOTTAR_UFØRETRYGD = 'MOTTAR_UFØRETRYGD',
+  ARBEIDER_PÅ_NORSKREGISTRERT_SKIP = 'ARBEIDER_PÅ_NORSKREGISTRERT_SKIP',
+  ARBEIDER_PÅ_NORSK_SOKKEL = 'ARBEIDER_PÅ_NORSK_SOKKEL',
+  ARBEIDER_FOR_ET_NORSK_FLYSELSKAP = 'ARBEIDER_FOR_ET_NORSK_FLYSELSKAP',
+  ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON = 'ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON',
+  MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
+  MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
+  MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET = 'MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET',
 }
 
 const annenForeldersAktivitetValg: Record<
@@ -31,6 +44,51 @@ const annenForeldersAktivitetValg: Record<
   UTSENDT_ARBEIDSTAKER: {
     title: 'Utsendt arbeidstaker',
     value: AnnenForelderAktivitet.UTSENDT_ARBEIDSTAKER,
+  },
+  // Annen forelders aktivitet valg som kun gjelder dersom annen forelder er omfattet av norsk lovgivning
+  ARBEIDER: {
+    title: 'Arbeider',
+    value: AnnenForelderAktivitet.ARBEIDER,
+  },
+  SELVSTENDIG_NÆRINGSDRIVENDE: {
+    title: 'Selvstendig næringsdrivende',
+    value: AnnenForelderAktivitet.SELVSTENDIG_NÆRINGSDRIVENDE,
+  },
+  UTSENDT_ARBEIDSTAKER_FRA_NORGE: {
+    title: 'Utsendt arbeidstaker fra Norge',
+    value: AnnenForelderAktivitet.UTSENDT_ARBEIDSTAKER_FRA_NORGE,
+  },
+  MOTTAR_UFØRETRYGD: {
+    title: 'Mottar uføretrygd',
+    value: AnnenForelderAktivitet.MOTTAR_UFØRETRYGD,
+  },
+  ARBEIDER_PÅ_NORSKREGISTRERT_SKIP: {
+    title: 'Arbeider på norskregistrert skip',
+    value: AnnenForelderAktivitet.ARBEIDER_PÅ_NORSKREGISTRERT_SKIP,
+  },
+  ARBEIDER_PÅ_NORSK_SOKKEL: {
+    title: 'Arbeider på norsk sokkel',
+    value: AnnenForelderAktivitet.ARBEIDER_PÅ_NORSK_SOKKEL,
+  },
+  ARBEIDER_FOR_ET_NORSK_FLYSELSKAP: {
+    title: 'Arbeider for et norsk flyselskap',
+    value: AnnenForelderAktivitet.ARBEIDER_FOR_ET_NORSK_FLYSELSKAP,
+  },
+  ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON: {
+    title: 'Arbeider ved utenlandsk utenriksstasjon',
+    value: AnnenForelderAktivitet.ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON,
+  },
+  MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET: {
+    title: 'Mottar utbetaling fra NAV under opphold i utlandet',
+    value: AnnenForelderAktivitet.MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
+  },
+  MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET: {
+    title: 'Mottar uføretrygd fra Norge under opphold i utlandet',
+    value: AnnenForelderAktivitet.MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
+  },
+  MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET: {
+    title: 'Mottar pensjon fra Norge under opphold i utlandet',
+    value: AnnenForelderAktivitet.MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
   },
 };
 


### PR DESCRIPTION
Når "annen forelder omfattet av norsk lovgivning" er valgt som utdypende vilkårsvurdering på vilkåret "Bosatt i riket", dukker det opp andre valg for annen forelders aktivitet i kompetanseskjemaet. Disse valgene manglet i enumen `AnnenForelderAktivitet` og gjorde at vi ikke fant noen av de relevante begrunnelsene.

Har nå lagt til alle de manglende aktivitetene.