### PR TITLE
Gjør "endret utbetaling"-felt til dropdown

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
@@ -1,6 +1,7 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
 import { endretUtbetalingsperioderDeltBostedTriggereValgUtbetaling, Endringsårsak } from '../typer';
 import { hentNasjonaleTriggereRegler, erNasjonalBegrunnelse } from './utils';
+import { Rule } from 'sanity';
 
 const erEndretUtbetalingAvTypeDeltBosted = document =>
   document[BegrunnelseDokumentNavn.ENDRINGSAARSAKER] &&
@@ -16,7 +17,7 @@ export const endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = {
   },
   hidden: ({ document }) =>
     !erEndretUtbetalingAvTypeDeltBosted(document) || !erNasjonalBegrunnelse(document),
-  validation: rule => [
+  validation: (rule: Rule) => [
     rule.custom((currentValue, { document }) => {
       if (erEndretUtbetalingAvTypeDeltBosted(document) && currentValue === undefined) {
         return 'Du må krysse av for et alternativ';

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endretUtbetalingPeriodeDeltBostedTrigger.ts
@@ -13,7 +13,6 @@ export const endretUtbetalingsperiodeDeltBostedUtbetalingTrigger = {
   of: [{ type: SanityTyper.STRING }],
   options: {
     list: endretUtbetalingsperioderDeltBostedTriggereValgUtbetaling,
-    layout: 'radio',
   },
   hidden: ({ document }) =>
     !erEndretUtbetalingAvTypeDeltBosted(document) || !erNasjonalBegrunnelse(document),


### PR DESCRIPTION
Nå kan vi ikke fjerne endret utbetaling-valg dersom det er satt fordi vi bruker radioknapper. Endrer så vi bruker dropdown som har mulighet til å velge undefined som verdi. 

Før:
![image](https://github.com/navikt/familie-sanity-brev/assets/17828446/b3c5395a-38cd-45a4-aeb8-3e7918234b20)

Etter:
![image](https://github.com/navikt/familie-sanity-brev/assets/17828446/683cd519-d365-4c74-a252-0deb31996afa)
