### PR TITLE
La oss velge rolle på endret utbetaling begrunnelser

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
@@ -1,21 +1,13 @@
 import * as React from 'react';
 import { BegrunnelseDokumentNavn, DokumentNavn, SanityTyper } from '../../../../util/typer';
 import styled from 'styled-components';
-import {
-  eøsFlettefelter,
-  flettefelter,
-  hjemler,
-  hjemlerFolketrygdloven,
-  vilkår,
-  VilkårRolle,
-} from './typer';
+import { eøsFlettefelter, flettefelter, hjemler, hjemlerFolketrygdloven, vilkår } from './typer';
 import { triggesAv } from './triggesAv';
 import { apiNavnValideringerBegrunnelse } from './valideringer';
 import { validerBegrunnelse } from './validerBegrunnelse';
 import {
   erNasjonalEllerInstitusjonsBegrunnelse,
   lagVilkårManglerForNasjonalEllerInstitusjonBegrunnelse,
-  rolleSkalVises,
   validerFlettefeltErGyldigForBehandlingstema,
 } from './utils';
 import { Mappe, mapperTilMenynavn } from './mapper';
@@ -27,6 +19,7 @@ import { begunnelseType } from './sanityMappeFelt/begrunnelsetype';
 import { begrunnelseTema } from './sanityMappeFelt/begrunnelsetema';
 import { fagsakType } from './sanityMappeFelt/fagsakType';
 import { periodeType } from './sanityMappeFelt/periodeType';
+import { rolle } from './sanityMappeFelt/rolle';
 
 const begrunnelseFlettefelt = {
   name: DokumentNavn.FLETTEFELT,
@@ -238,32 +231,7 @@ const begrunnelse = {
       hidden: context => !erNasjonalEllerInstitusjonsBegrunnelse(context.document),
     },
 
-    {
-      title: 'Rolle',
-      type: SanityTyper.ARRAY,
-      name: BegrunnelseDokumentNavn.ROLLE,
-      of: [{ type: SanityTyper.STRING }],
-      options: {
-        list: [
-          {
-            title: 'Søker',
-            value: VilkårRolle.SOKER,
-          },
-          {
-            title: 'Barn',
-            value: VilkårRolle.BARN,
-          },
-        ],
-      },
-      hidden: context => !rolleSkalVises(context.document),
-      validation: rule =>
-        rule.custom((rolleListe, context) => {
-          if (rolleSkalVises(context.document)) {
-            return !rolleListe || rolleListe.length === 0 ? 'Må velge minst en rolle' : true;
-          }
-          return true;
-        }),
-    },
+    rolle,
     ...triggesAv,
     editor(DokumentNavn.BOKMAAL, 'Bokmål'),
     editor(DokumentNavn.NYNORSK, 'Nynorsk'),

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endretUtbetalingPeriodeTrigger.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endretUtbetalingPeriodeTrigger.ts
@@ -1,6 +1,6 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
 import { endretUtbetalingsperioderTriggereValg } from '../typer';
-import { erEndretUtbetaling } from './endringsårsakTrigger';
+import { erEndretUtbetalingBegrunnelse } from './endringsårsakTrigger';
 import { hentNasjonaleTriggereRegler, erNasjonalBegrunnelse } from './utils';
 
 export const endretUtbetalingsperiodeTriggere = {
@@ -11,6 +11,7 @@ export const endretUtbetalingsperiodeTriggere = {
   options: {
     list: endretUtbetalingsperioderTriggereValg,
   },
-  hidden: ({ document }) => !erEndretUtbetaling(document) || !erNasjonalBegrunnelse(document),
+  hidden: ({ document }) =>
+    !erEndretUtbetalingBegrunnelse(document) || !erNasjonalBegrunnelse(document),
   validation: rule => hentNasjonaleTriggereRegler(rule),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endringsårsakTrigger.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/endringsårsakTrigger.ts
@@ -3,7 +3,7 @@ import { endringsårsaker } from '../typer';
 import { Mappe } from '../mapper';
 import { hentNasjonaleTriggereRegler, erNasjonalBegrunnelse } from './utils';
 
-export const erEndretUtbetaling: (document) => boolean = document =>
+export const erEndretUtbetalingBegrunnelse: (document) => boolean = document =>
   document[DokumentNavn.MAPPE] &&
   (document[DokumentNavn.MAPPE].includes(Mappe.ENDRET_UTBETALINGSPERIODE) ||
     document[DokumentNavn.MAPPE].includes(Mappe.ETTER_ENDRET_UTBETALINGSPERIODE));
@@ -16,11 +16,13 @@ export const endringsårsakTrigger = {
   options: {
     list: endringsårsaker,
   },
-  hidden: ({ document }) => !erEndretUtbetaling(document) || !erNasjonalBegrunnelse(document),
+  hidden: ({ document }) =>
+    !erEndretUtbetalingBegrunnelse(document) || !erNasjonalBegrunnelse(document),
   validation: rule => [
     rule
       .custom((endringsårsaktriggere, context) => {
-        const _erEndretUtbetaling = context.document && erEndretUtbetaling(context.document);
+        const _erEndretUtbetaling =
+          context.document && erEndretUtbetalingBegrunnelse(context.document);
         const endringsårsakErValgt = endringsårsaktriggere && endringsårsaktriggere.length !== 0;
 
         return !_erEndretUtbetaling || endringsårsakErValgt

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/øvrigeTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/øvrigeTriggere.ts
@@ -1,5 +1,5 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { erEndretUtbetaling } from './endringsårsakTrigger';
+import { erEndretUtbetalingBegrunnelse } from './endringsårsakTrigger';
 import { vilkårTriggerTilMenynavn, øvrigeTriggertyper } from '../typer';
 import {
   erNasjonalEllerInstitusjonsBegrunnelse,
@@ -15,6 +15,6 @@ export const øvrigeTriggere = {
     list: øvrigeTriggertyper.map(trigger => vilkårTriggerTilMenynavn[trigger]),
   },
   hidden: ({ document }) =>
-    erEndretUtbetaling(document) || !erNasjonalEllerInstitusjonsBegrunnelse(document),
+    erEndretUtbetalingBegrunnelse(document) || !erNasjonalEllerInstitusjonsBegrunnelse(document),
   validation: rule => lagUtfyltNasjonaltFeltMenFeilBehandlingstemaRegel(rule),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/rolle.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/rolle.ts
@@ -1,0 +1,53 @@
+import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
+import { Vilkår } from '../typer';
+import { erInstitusjonsBegrunnelse } from '../institusjon/utils';
+import { erEndretUtbetalingBegrunnelse } from '../nasjonaleTriggere/endringsårsakTrigger';
+import { Rule } from 'sanity';
+
+export enum Rolle {
+  SOKER = 'SOKER',
+  BARN = 'BARN',
+}
+
+const gjelderBosattIRiketVilkår = (dokument?: any) =>
+  dokument?.vilkaar && dokument.vilkaar.includes(Vilkår.BOSATT_I_RIKET);
+
+const gjelderLovligOppholdVilkår = (dokument?: any) =>
+  dokument?.vilkaar && dokument.vilkaar.includes(Vilkår.LOVLIG_OPPHOLD);
+
+const rolleSkalVises = (dokument?: any): boolean =>
+  !erInstitusjonsBegrunnelse(dokument) &&
+  (gjelderBosattIRiketVilkår(dokument) ||
+    gjelderLovligOppholdVilkår(dokument) ||
+    erEndretUtbetalingBegrunnelse(dokument));
+
+export const rolleTilMenyValg = (rolle: Rolle): Menyvalg<Rolle> => {
+  const rolleTilMenynavn = (rolle: Rolle): string => {
+    switch (rolle) {
+      case Rolle.SOKER:
+        return 'Søker';
+      case Rolle.BARN:
+        return 'Barn';
+    }
+  };
+
+  return { title: rolleTilMenynavn(rolle), value: rolle };
+};
+
+export const rolle = {
+  title: 'Rolle',
+  type: SanityTyper.ARRAY,
+  name: BegrunnelseDokumentNavn.ROLLE,
+  of: [{ type: SanityTyper.STRING }],
+  options: {
+    list: Object.values(Rolle).map(rolle => rolleTilMenyValg(rolle)),
+  },
+  hidden: context => !rolleSkalVises(context.document),
+  validation: (rule: Rule) =>
+    rule.custom((rolleListe: Rolle[] | undefined, context) => {
+      if (rolleSkalVises(context.document)) {
+        return !rolleListe || rolleListe.length === 0 ? 'Må velge minst en rolle' : true;
+      }
+      return true;
+    }),
+};

--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -60,11 +60,6 @@ export enum VilkårTriggere {
   BARN_DØD = 'BARN_DØD',
 }
 
-export enum VilkårRolle {
-  SOKER = 'SOKER',
-  BARN = 'BARN',
-}
-
 //NB: Endrer du på disse bør du endre i ba-sak først (Før du tester lokalt også)
 export const lovligOppholdTriggerTyper = [VilkårTriggere.VURDERING_ANNET_GRUNNLAG];
 export const bosattIRiketTriggerTyper = [

--- a/src/schemas/baks/begrunnelse/ba-sak/utils.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/utils.ts
@@ -4,17 +4,10 @@ import {
   flettefelter,
   InstitusjonBegrunnelse,
   NasjonalBegrunnelse,
-  Vilkår,
 } from './typer';
 import { erEøsBegrunnelse } from './eøs/eøsTriggere/utils';
 import { erNasjonalBegrunnelse } from './nasjonaleTriggere/utils';
 import { erInstitusjonsBegrunnelse } from './institusjon/utils';
-
-export const rolleSkalVises = (dokument?: any): boolean =>
-  !erInstitusjonsBegrunnelse(dokument) &&
-  dokument?.vilkaar &&
-  (dokument.vilkaar.includes(Vilkår.BOSATT_I_RIKET) ||
-    dokument.vilkaar.includes(Vilkår.LOVLIG_OPPHOLD));
 
 export const validerFlettefeltErGyldigForBehandlingstema = (flettefelt, context) => {
   if (

--- a/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
@@ -4,11 +4,9 @@ import {
   KSBegrunnelseDokumentNavn,
   SanityTyper,
 } from '../../../../util/typer';
-import { VilkårRolle } from '../ba-sak/typer';
 import { triggere } from './triggere';
 import { eøsHjemler } from '../ba-sak/eøs/hjemler';
 import { vilkårsvurderingTriggere } from './vilkårsvurderingerTriggere';
-import { rolleSkalVises } from '../ba-sak/utils';
 import { validerBegrunnelse } from '../ba-sak/validerBegrunnelse';
 import {
   begrunnelseEØSFlettefelt,
@@ -23,6 +21,7 @@ import { apiNavnValideringerBegrunnelse } from './valideringer';
 import { utdypendeVilkårsvurderinger } from './utdypendeVilkårsvurderinger';
 import { endringsårsakTriggere } from './endringsårsakTriggere';
 import { endretUtbetalingsperiodeTriggere } from './endretUtbetalingPeriodeTriggere';
+import { rolle } from '../ba-sak/sanityMappeFelt/rolle';
 
 const editor = (maalform, tittel) => ({
   name: maalform,
@@ -73,32 +72,7 @@ const begrunnelse = {
     },
     hjemler,
     ...eøsHjemler,
-    {
-      title: 'Rolle',
-      type: SanityTyper.ARRAY,
-      name: BegrunnelseDokumentNavn.ROLLE,
-      of: [{ type: SanityTyper.STRING }],
-      options: {
-        list: [
-          {
-            title: 'Søker',
-            value: VilkårRolle.SOKER,
-          },
-          {
-            title: 'Barn',
-            value: VilkårRolle.BARN,
-          },
-        ],
-      },
-      hidden: context => !rolleSkalVises(context.document),
-      validation: rule =>
-        rule.custom((rolleListe, context) => {
-          if (rolleSkalVises(context.document)) {
-            return !rolleListe || rolleListe.length === 0 ? 'Må velge minst en rolle' : true;
-          }
-          return true;
-        }),
-    },
+    rolle,
     {
       title: 'Støtter fritekst',
       type: SanityTyper.BOOLEAN,

--- a/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ks-sak/begrunnelse.tsx
@@ -1,9 +1,4 @@
-import {
-  BegrunnelseDokumentNavn,
-  DokumentNavn,
-  KSBegrunnelseDokumentNavn,
-  SanityTyper,
-} from '../../../../util/typer';
+import { DokumentNavn, KSBegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
 import { triggere } from './triggere';
 import { eøsHjemler } from '../ba-sak/eøs/hjemler';
 import { vilkårsvurderingTriggere } from './vilkårsvurderingerTriggere';


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15717)
[Slacktråd](https://nav-it.slack.com/archives/C01NSLQTG7P/p1695813188760519)

Vi har begrunnelser av typen endret utbetaling og etter endret utbetaling som vi ønsker at kun skal komme dersom personen som trigger begrunnelsen er søker eller barn. For eksempel skal [denne begrunnelsen](https://familie-brev.sanity.studio/ba-brev/desk/begrunnelseBa;etterEndretUtbetalingsperiode;begrunnelse-763bafcb-829b-4a65-ad5a-f74dc555b65d%2Crev%3D2023-09-28T08%253A46%253A49.897807Z%252Fh26rAhFEYSUtDGXJE3ZueM) kun komme om det er søker matcher begrunnelsen, mens [denne begrunnelsen](https://familie-brev.sanity.studio/ba-brev/desk/begrunnelseBa;etterEndretUtbetalingsperiode;begrunnelse-722f1d53-203f-4006-85b4-1d915607428f) kun gjelder barn. 

Gjør så vi kan velge rolle for begrunnelser som gjelder endret utbetaling og etter endret utbetaling