### PR TITLE
Rename visningsnavn + feilmeldingstekst for vedtakResultat

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/vedtakResultat.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/vedtakResultat.tsx
@@ -27,7 +27,7 @@ export const vedtakResultatTilMenyValg = (
 };
 
 export const vedtakResultat = {
-  title: 'Resultat',
+  title: 'Resultat i perioden for gjeldende person(er)',
   type: SanityTyper.STRING,
   name: BegrunnelseDokumentNavn.VEDTAK_RESULTAT,
   options: {
@@ -35,5 +35,5 @@ export const vedtakResultat = {
       vedtakResultatTilMenyValg(vedtakResultat),
     ),
   },
-  validation: rule => rule.required().error('VedtakResultat ikke valgt'),
+  validation: rule => rule.required().error('Resultat i perioden ikke valgt'),
 };


### PR DESCRIPTION
Syns gammelt navn var utydelig, så har funnet et navn som er mer beskrivende. Kan være verdt å vite at vedtakResultat er det samme som sanityPeriodeResultat i ba-sak.