### PR TITLE
Fjern validering for øvrige triggere

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/utils.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/utils.ts
@@ -37,14 +37,6 @@ export const lagUtfyltNasjonaltFeltMenFeilRegelverkRegel = rule =>
     return true;
   });
 
-export const lagUtfyltØvrigeTriggereFeltMenFeilRegelverkRegel = rule =>
-  rule.custom((nåVerdi, context) => {
-    if (nåVerdi !== undefined && !erInstitusjonsBegrunnelse(context.document)) {
-      return 'Feltet er ikke gyldig for regelverk Institusjon.';
-    }
-    return true;
-  });
-
 export const lagVilkårManglerForNasjonalEllerInstitusjonBegrunnelse = rule =>
   rule.custom((nåVerdi, context) => {
     if (erNasjonalEllerInstitusjonsBegrunnelse(context.document) && nåVerdi === undefined) {

--- a/src/schemas/baks/begrunnelse/ba-sak/øvrigeTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/øvrigeTriggere.ts
@@ -1,7 +1,6 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
 import { erEndretUtbetalingBegrunnelse } from './nasjonaleTriggere/endringsårsakTrigger';
 import { vilkårTriggerTilMenynavn, øvrigeTriggertyper } from './typer';
-import { lagUtfyltØvrigeTriggereFeltMenFeilRegelverkRegel } from './utils';
 
 export const øvrigeTriggere = {
   title: 'Øvrige triggere',
@@ -12,5 +11,4 @@ export const øvrigeTriggere = {
     list: øvrigeTriggertyper.map(trigger => vilkårTriggerTilMenynavn[trigger]),
   },
   hidden: ({ document }) => erEndretUtbetalingBegrunnelse(document),
-  validation: rule => lagUtfyltØvrigeTriggereFeltMenFeilRegelverkRegel(rule),
 };


### PR DESCRIPTION
Fjerner validering for øvrige triggere fordi det skal gjelde uavhengig av regelverk.