### PR TITLE
Legg til triggere for bor med søker EØS

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/borMedSøkerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/borMedSøkerTriggere.ts
@@ -1,9 +1,5 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
 import { borMedSøkerTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from '../typer';
-import {
-  erNasjonalEllerInstitusjonsBegrunnelse,
-  lagUtfyltNasjonaltFeltMenFeilRegelverkRegel,
-} from '../utils';
 import { lagInstitusjonBorMedSøkerRegel } from '../institusjon/utils';
 
 export const borMedSøkerTriggere = {
@@ -14,14 +10,6 @@ export const borMedSøkerTriggere = {
   options: {
     list: borMedSøkerTriggerTyper.map(trigger => vilkårTriggerTilMenynavn[trigger]),
   },
-  hidden: ({ document }) =>
-    !(
-      erNasjonalEllerInstitusjonsBegrunnelse(document) &&
-      document.vilkaar &&
-      document.vilkaar.includes(Vilkår.BOR_MED_SOKER)
-    ),
-  validation: rule => [
-    lagUtfyltNasjonaltFeltMenFeilRegelverkRegel(rule),
-    lagInstitusjonBorMedSøkerRegel(rule),
-  ],
+  hidden: ({ document }) => !(document.vilkaar && document.vilkaar.includes(Vilkår.BOR_MED_SOKER)),
+  validation: rule => [lagInstitusjonBorMedSøkerRegel(rule)],
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/triggesAv.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/triggesAv.ts
@@ -31,6 +31,7 @@ const EØSBegrunnelseTriggere = [
   barnetsBostedslandTrigger,
   kompetentLandTrigger,
   vilkårsvurderingTriggere,
+  borMedSøkerTriggere,
   utdypendeVilkårsvurderingerForEØSTriggere,
 ];
 


### PR DESCRIPTION
Favro: NAV-17079

Vi ønsker å kunne trigge EØS-begrunnelser basert på delt bosted, som ligger under vilkåret Bor med søker. 
Fjerner skjuling av triggeret hvis begrunnelsen ikke er nasjonal, og validering av at triggeret ikke kunne fylles for EØS-begrunnelser