### PR TITLE
Ta høyde for at vi har ulike vilkårsenumer for nasjonal og eøs

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
@@ -1,6 +1,6 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
-import { Vilkår as EøsVilkår } from './eøs/eøsTriggere/vilkårsvurderingerTriggere';
-import { Vilkår as NasjonaleVilkår } from './typer';
+import { EøsVilkår } from './eøs/eøsTriggere/vilkårsvurderingerTriggere';
+import { NasjonaleVilkår } from './typer';
 import { lagInstitusjonBorMedSøkerRegel } from './institusjon/utils';
 
 enum BorMedSøkerTriggere {

--- a/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
@@ -1,6 +1,6 @@
-import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { borMedSøkerTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from '../typer';
-import { lagInstitusjonBorMedSøkerRegel } from '../institusjon/utils';
+import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
+import { borMedSøkerTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from './typer';
+import { lagInstitusjonBorMedSøkerRegel } from './institusjon/utils';
 
 export const borMedSøkerTriggere = {
   title: 'Triggere for "Bor med søker"',

--- a/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
@@ -3,7 +3,7 @@ import { EøsVilkår } from './eøs/eøsTriggere/vilkårsvurderingerTriggere';
 import { NasjonaleVilkår } from './typer';
 import { lagInstitusjonBorMedSøkerRegel } from './institusjon/utils';
 
-enum BorMedSøkerTriggere {
+export enum BorMedSøkerTriggere {
   VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
   DELT_BOSTED = 'DELT_BOSTED',
   DELT_BOSTED_SKAL_IKKE_DELES = 'DELT_BOSTED_SKAL_IKKE_DELES',

--- a/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/borMedSøkerTriggere.ts
@@ -1,6 +1,28 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../util/typer';
-import { borMedSøkerTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from './typer';
+import { Vilkår as EøsVilkår } from './eøs/eøsTriggere/vilkårsvurderingerTriggere';
+import { Vilkår as NasjonaleVilkår } from './typer';
 import { lagInstitusjonBorMedSøkerRegel } from './institusjon/utils';
+
+enum BorMedSøkerTriggere {
+  VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
+  DELT_BOSTED = 'DELT_BOSTED',
+  DELT_BOSTED_SKAL_IKKE_DELES = 'DELT_BOSTED_SKAL_IKKE_DELES',
+}
+
+const vilkårTriggerTilMenynavn: Record<BorMedSøkerTriggere, { title: string; value: string }> = {
+  DELT_BOSTED: {
+    title: 'Delt bosted: skal deles',
+    value: BorMedSøkerTriggere.DELT_BOSTED,
+  },
+  DELT_BOSTED_SKAL_IKKE_DELES: {
+    title: 'Delt bosted: skal ikke deles',
+    value: BorMedSøkerTriggere.DELT_BOSTED_SKAL_IKKE_DELES,
+  },
+  VURDERING_ANNET_GRUNNLAG: {
+    title: 'Vurdering annet grunnlag',
+    value: BorMedSøkerTriggere.VURDERING_ANNET_GRUNNLAG,
+  },
+};
 
 export const borMedSøkerTriggere = {
   title: 'Triggere for "Bor med søker"',
@@ -8,10 +30,10 @@ export const borMedSøkerTriggere = {
   name: BegrunnelseDokumentNavn.BOR_MED_SØKER_TRIGGERE,
   of: [{ type: SanityTyper.STRING }],
   options: {
-    list: borMedSøkerTriggerTyper.map(trigger => vilkårTriggerTilMenynavn[trigger]),
+    list: Object.values(BorMedSøkerTriggere).map(trigger => vilkårTriggerTilMenynavn[trigger]),
   },
   hidden: ({ document }) =>
-    !(document.vilkaar && document.vilkaar.includes(Vilkår.BOR_MED_SOKER)) &&
-    !(document.eosVilkaar && document.eosVilkaar.includes(Vilkår.BOR_MED_SOKER)),
+    !(document.vilkaar && document.vilkaar.includes(NasjonaleVilkår.BOR_MED_SOKER)) &&
+    !(document.eosVilkaar && document.eosVilkaar.includes(EøsVilkår.BOR_MED_SØKER)),
   validation: rule => [lagInstitusjonBorMedSøkerRegel(rule)],
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/eøs/eøsTriggere/vilkårsvurderingerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/eøs/eøsTriggere/vilkårsvurderingerTriggere.ts
@@ -6,7 +6,7 @@ import {
 } from './utils';
 import { EØSTriggerType } from './hvilkeTriggereSkalBrukes';
 
-export enum Vilkår {
+export enum EøsVilkår {
   UNDER_18_ÅR = 'UNDER_18_ÅR',
   BOR_MED_SØKER = 'BOR_MED_SØKER',
   GIFT_PARTNERSKAP = 'GIFT_PARTNERSKAP',
@@ -15,13 +15,13 @@ export enum Vilkår {
   UTVIDET_BARNETRYGD = 'UTVIDET_BARNETRYGD',
 }
 
-const vilkårValg: Record<Vilkår, { title: string; value: Vilkår }> = {
-  UNDER_18_ÅR: { title: 'Under 18 år', value: Vilkår.UNDER_18_ÅR },
-  BOR_MED_SØKER: { title: 'Bor med søker', value: Vilkår.BOR_MED_SØKER },
-  GIFT_PARTNERSKAP: { title: 'Gift partnerskap', value: Vilkår.GIFT_PARTNERSKAP },
-  BOSATT_I_RIKET: { title: 'Bosatt i riket', value: Vilkår.BOSATT_I_RIKET },
-  LOVLIG_OPPHOLD: { title: 'Lovlig opphold', value: Vilkår.LOVLIG_OPPHOLD },
-  UTVIDET_BARNETRYGD: { title: 'Utvidet barnetrygd', value: Vilkår.UTVIDET_BARNETRYGD },
+const vilkårValg: Record<EøsVilkår, { title: string; value: EøsVilkår }> = {
+  UNDER_18_ÅR: { title: 'Under 18 år', value: EøsVilkår.UNDER_18_ÅR },
+  BOR_MED_SØKER: { title: 'Bor med søker', value: EøsVilkår.BOR_MED_SØKER },
+  GIFT_PARTNERSKAP: { title: 'Gift partnerskap', value: EøsVilkår.GIFT_PARTNERSKAP },
+  BOSATT_I_RIKET: { title: 'Bosatt i riket', value: EøsVilkår.BOSATT_I_RIKET },
+  LOVLIG_OPPHOLD: { title: 'Lovlig opphold', value: EøsVilkår.LOVLIG_OPPHOLD },
+  UTVIDET_BARNETRYGD: { title: 'Utvidet barnetrygd', value: EøsVilkår.UTVIDET_BARNETRYGD },
 };
 
 export const vilkårsvurderingTriggere = {
@@ -34,7 +34,7 @@ export const vilkårsvurderingTriggere = {
     },
   ],
   options: {
-    list: Object.values(Vilkår).map(vilkår => vilkårValg[vilkår]),
+    list: Object.values(EøsVilkår).map(vilkår => vilkårValg[vilkår]),
   },
 
   hidden: ({ document }) =>

--- a/src/schemas/baks/begrunnelse/ba-sak/institusjon/utils.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/institusjon/utils.ts
@@ -1,7 +1,8 @@
 import { BegrunnelseDokumentNavn } from '../../../../../util/typer';
-import { Begrunnelse, InstitusjonBegrunnelse, NasjonaleVilkår, VilkårTriggere } from '../typer';
+import { Begrunnelse, InstitusjonBegrunnelse, NasjonaleVilkår } from '../typer';
 import { erSakspesifikkBegrunnelse } from '../sanityMappeFelt/valgbarhet';
 import { FagsakType } from '../sanityMappeFelt/fagsakType';
+import { BorMedSøkerTriggere } from '../borMedSøkerTriggere';
 
 export const erInstitusjonsBegrunnelse = (
   begrunnelse: Begrunnelse,
@@ -23,8 +24,8 @@ export const lagInvaliderUtvidetForInstitusjonRegel = rule =>
 export const lagInstitusjonBorMedSøkerRegel = rule =>
   rule.custom((nåVerdi, context) => {
     if (erInstitusjonsBegrunnelse(context.document) && nåVerdi !== undefined) {
-      return nåVerdi.includes(VilkårTriggere.DELT_BOSTED) ||
-        nåVerdi.includes(VilkårTriggere.DELT_BOSTED_SKAL_IKKE_DELES)
+      return nåVerdi.includes(BorMedSøkerTriggere.DELT_BOSTED) ||
+        nåVerdi.includes(BorMedSøkerTriggere.DELT_BOSTED_SKAL_IKKE_DELES)
         ? 'Delt bosted er ikke i bruk i institusjonssaker'
         : true;
     }

--- a/src/schemas/baks/begrunnelse/ba-sak/institusjon/utils.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/institusjon/utils.ts
@@ -1,5 +1,5 @@
 import { BegrunnelseDokumentNavn } from '../../../../../util/typer';
-import { Begrunnelse, InstitusjonBegrunnelse, Vilkår, VilkårTriggere } from '../typer';
+import { Begrunnelse, InstitusjonBegrunnelse, NasjonaleVilkår, VilkårTriggere } from '../typer';
 import { erSakspesifikkBegrunnelse } from '../sanityMappeFelt/valgbarhet';
 import { FagsakType } from '../sanityMappeFelt/fagsakType';
 
@@ -13,7 +13,7 @@ export const erInstitusjonsBegrunnelse = (
 export const lagInvaliderUtvidetForInstitusjonRegel = rule =>
   rule.custom((nåVerdi, context) => {
     if (erInstitusjonsBegrunnelse(context.document) && nåVerdi !== undefined) {
-      return nåVerdi.includes(Vilkår.UTVIDET_BARNETRYGD)
+      return nåVerdi.includes(NasjonaleVilkår.UTVIDET_BARNETRYGD)
         ? 'Utvidet barnetrygd er ikke i bruk i institusjonssaker'
         : true;
     }

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/bosattIRiketTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/bosattIRiketTriggere.ts
@@ -1,5 +1,5 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { bosattIRiketTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from '../typer';
+import { bosattIRiketTriggerTyper, NasjonaleVilkår, vilkårTriggerTilMenynavn } from '../typer';
 import {
   erNasjonalEllerInstitusjonsBegrunnelse,
   lagUtfyltNasjonaltFeltMenFeilRegelverkRegel,
@@ -17,7 +17,7 @@ export const bosattIRiketTriggere = {
     !(
       erNasjonalEllerInstitusjonsBegrunnelse(document) &&
       document.vilkaar &&
-      document.vilkaar.includes(Vilkår.BOSATT_I_RIKET)
+      document.vilkaar.includes(NasjonaleVilkår.BOSATT_I_RIKET)
     ),
   validation: rule => lagUtfyltNasjonaltFeltMenFeilRegelverkRegel(rule),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/giftPartnerskapTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/giftPartnerskapTriggere.ts
@@ -1,4 +1,4 @@
-import { giftPartnerskapTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from '../typer';
+import { giftPartnerskapTriggerTyper, NasjonaleVilkår, vilkårTriggerTilMenynavn } from '../typer';
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
 import {
   erNasjonalEllerInstitusjonsBegrunnelse,
@@ -17,7 +17,7 @@ export const giftPartnerskapTriggere = {
     !(
       erNasjonalEllerInstitusjonsBegrunnelse(document) &&
       document.vilkaar &&
-      document.vilkaar.includes(Vilkår.GIFT_PARTNERSKAP)
+      document.vilkaar.includes(NasjonaleVilkår.GIFT_PARTNERSKAP)
     ),
   validation: rule => lagUtfyltNasjonaltFeltMenFeilRegelverkRegel(rule),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/lovligOppholdTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/lovligOppholdTriggere.ts
@@ -1,5 +1,5 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { lovligOppholdTriggerTyper, Vilkår, vilkårTriggerTilMenynavn } from '../typer';
+import { lovligOppholdTriggerTyper, NasjonaleVilkår, vilkårTriggerTilMenynavn } from '../typer';
 import {
   erNasjonalEllerInstitusjonsBegrunnelse,
   lagUtfyltNasjonaltFeltMenFeilRegelverkRegel,
@@ -17,7 +17,7 @@ export const lovligOppholdTriggere = {
     !(
       erNasjonalEllerInstitusjonsBegrunnelse(document) &&
       document.vilkaar &&
-      document.vilkaar.includes(Vilkår.LOVLIG_OPPHOLD)
+      document.vilkaar.includes(NasjonaleVilkår.LOVLIG_OPPHOLD)
     ),
   validation: rule => lagUtfyltNasjonaltFeltMenFeilRegelverkRegel(rule),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/utvidetBarnetrygdTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/nasjonaleTriggere/utvidetBarnetrygdTriggere.ts
@@ -1,5 +1,5 @@
 import { BegrunnelseDokumentNavn, SanityTyper } from '../../../../../util/typer';
-import { utvidetBarnetrygdTriggertyper, Vilkår, vilkårTriggerTilMenynavn } from '../typer';
+import { utvidetBarnetrygdTriggertyper, NasjonaleVilkår, vilkårTriggerTilMenynavn } from '../typer';
 import { erEøsBegrunnelse } from '../eøs/eøsTriggere/utils';
 import { hentNasjonaleTriggereRegler, erNasjonalBegrunnelse } from './utils';
 
@@ -15,7 +15,7 @@ export const utvidetBarnetrygdTriggere = {
     !(
       erNasjonalBegrunnelse(document) &&
       document.vilkaar &&
-      document.vilkaar.includes(Vilkår.UTVIDET_BARNETRYGD)
+      document.vilkaar.includes(NasjonaleVilkår.UTVIDET_BARNETRYGD)
     ) || erEøsBegrunnelse(document),
   validation: rule => hentNasjonaleTriggereRegler(rule),
 };

--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/rolle.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/rolle.ts
@@ -1,5 +1,5 @@
 import { BegrunnelseDokumentNavn, Menyvalg, SanityTyper } from '../../../../../util/typer';
-import { Vilkår } from '../typer';
+import { NasjonaleVilkår } from '../typer';
 import { erInstitusjonsBegrunnelse } from '../institusjon/utils';
 import { erEndretUtbetalingBegrunnelse } from '../nasjonaleTriggere/endringsårsakTrigger';
 import { Rule } from 'sanity';
@@ -10,10 +10,10 @@ export enum Rolle {
 }
 
 const gjelderBosattIRiketVilkår = (dokument?: any) =>
-  dokument?.vilkaar && dokument.vilkaar.includes(Vilkår.BOSATT_I_RIKET);
+  dokument?.vilkaar && dokument.vilkaar.includes(NasjonaleVilkår.BOSATT_I_RIKET);
 
 const gjelderLovligOppholdVilkår = (dokument?: any) =>
-  dokument?.vilkaar && dokument.vilkaar.includes(Vilkår.LOVLIG_OPPHOLD);
+  dokument?.vilkaar && dokument.vilkaar.includes(NasjonaleVilkår.LOVLIG_OPPHOLD);
 
 const rolleSkalVises = (dokument?: any): boolean =>
   !erInstitusjonsBegrunnelse(dokument) &&

--- a/src/schemas/baks/begrunnelse/ba-sak/triggesAv.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/triggesAv.ts
@@ -1,4 +1,4 @@
-import { borMedSøkerTriggere } from './nasjonaleTriggere/borMedSøkerTriggere';
+import { borMedSøkerTriggere } from './borMedSøkerTriggere';
 import { lovligOppholdTriggere } from './nasjonaleTriggere/lovligOppholdTriggere';
 import { bosattIRiketTriggere } from './nasjonaleTriggere/bosattIRiketTriggere';
 import { giftPartnerskapTriggere } from './nasjonaleTriggere/giftPartnerskapTriggere';

--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -11,7 +11,7 @@ export const hjemler = ['2', '3', '4', '5', '9', '10', '11', '12', '14', '17', '
 export const hjemlerFolketrygdloven = ['2-5', '2-8'];
 
 //NB: Endrer du på disse bør du endre i ba-sak først (Før du tester lokalt også)
-export enum Vilkår {
+export enum NasjonaleVilkår {
   UNDER_18_ÅR = 'UNDER_18_ÅR',
   BOR_MED_SOKER = 'BOR_MED_SOKER',
   GIFT_PARTNERSKAP = 'GIFT_PARTNERSKAP',
@@ -21,12 +21,12 @@ export enum Vilkår {
 }
 
 export const vilkår = [
-  { title: 'Under 18 år', value: Vilkår.UNDER_18_ÅR },
-  { title: 'Bor med søker', value: Vilkår.BOR_MED_SOKER },
-  { title: 'Gift partnerskap', value: Vilkår.GIFT_PARTNERSKAP },
-  { title: 'Bosatt i riket', value: Vilkår.BOSATT_I_RIKET },
-  { title: 'Lovlig opphold', value: Vilkår.LOVLIG_OPPHOLD },
-  { title: 'Utvidet barnetrygd', value: Vilkår.UTVIDET_BARNETRYGD },
+  { title: 'Under 18 år', value: NasjonaleVilkår.UNDER_18_ÅR },
+  { title: 'Bor med søker', value: NasjonaleVilkår.BOR_MED_SOKER },
+  { title: 'Gift partnerskap', value: NasjonaleVilkår.GIFT_PARTNERSKAP },
+  { title: 'Bosatt i riket', value: NasjonaleVilkår.BOSATT_I_RIKET },
+  { title: 'Lovlig opphold', value: NasjonaleVilkår.LOVLIG_OPPHOLD },
+  { title: 'Utvidet barnetrygd', value: NasjonaleVilkår.UTVIDET_BARNETRYGD },
 ];
 
 export const flettefelter = [

--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -48,8 +48,6 @@ export const eøsFlettefelter = [
 export enum VilkårTriggere {
   VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
   MEDLEMSKAP = 'MEDLEMSKAP',
-  DELT_BOSTED = 'DELT_BOSTED',
-  DELT_BOSTED_SKAL_IKKE_DELES = 'DELT_BOSTED_SKAL_IKKE_DELES',
   MANGLER_OPPLYSNINGER = 'MANGLER_OPPLYSNINGER',
   SATSENDRING = 'SATSENDRING',
   BARN_MED_6_ÅRS_DAG = 'BARN_MED_6_ÅRS_DAG',
@@ -70,11 +68,6 @@ export const bosattIRiketTriggerTyper = [
 export const giftPartnerskapTriggerTyper = [
   VilkårTriggere.VURDERING_ANNET_GRUNNLAG,
   VilkårTriggere.MEDLEMSKAP,
-];
-export const borMedSøkerTriggerTyper = [
-  VilkårTriggere.VURDERING_ANNET_GRUNNLAG,
-  VilkårTriggere.DELT_BOSTED,
-  VilkårTriggere.DELT_BOSTED_SKAL_IKKE_DELES,
 ];
 export const øvrigeTriggertyper = [
   VilkårTriggere.BARN_MED_6_ÅRS_DAG,
@@ -100,14 +93,6 @@ export const vilkårTriggerTilMenynavn: Record<VilkårTriggere, { title: string;
   MEDLEMSKAP: {
     title: 'Medlemskap',
     value: VilkårTriggere.MEDLEMSKAP,
-  },
-  DELT_BOSTED: {
-    title: 'Delt bosted: skal deles',
-    value: VilkårTriggere.DELT_BOSTED,
-  },
-  DELT_BOSTED_SKAL_IKKE_DELES: {
-    title: 'Delt bosted: skal ikke deles',
-    value: VilkårTriggere.DELT_BOSTED_SKAL_IKKE_DELES,
   },
   BARN_MED_6_ÅRS_DAG: { title: 'Barn med 6 års dag', value: VilkårTriggere.BARN_MED_6_ÅRS_DAG },
   MANGLER_OPPLYSNINGER: {


### PR DESCRIPTION
I #499 la vi til bor med søker-triggeret for EØS, men glemte å ta høyde for at det er to ulike enumer for `Vilkår`, ett for nasjonal og ett for EØS.

I denne PRen fikser vi opp i det:
- Flytter triggerfilen opp fra `./nasjonaleTriggere` siden den skal brukes for både EØS og nasjonal
- Begynner på å splitte opp de store enumene for nasjonale triggere, ved å ta de som kun gjelder bor med søker inn i filen for triggeret
- Endrer navn på `Vilkår` og `Vilkår` til `NasjonaleVilkår` og `EøsVilkår`