### PR TITLE
Legg til flere utdypende-valg for EØS

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/eøs/eøsTriggere/utdypendeVilkårsvurderingerTriggere.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/eøs/eøsTriggere/utdypendeVilkårsvurderingerTriggere.ts
@@ -10,6 +10,12 @@ enum UtdypendeVilkårsvurderingForEØS {
   BARN_BOR_I_STORBRITANNIA = 'BARN_BOR_I_STORBRITANNIA',
   BARN_BOR_I_STORBRITANNIA_MED_SØKER = 'BARN_BOR_I_STORBRITANNIA_MED_SØKER',
   BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER = 'BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER',
+  BARN_BOR_I_EØS = 'BARN_BOR_I_EØS',
+  BARN_BOR_I_EØS_MED_SØKER = 'BARN_BOR_I_EØS_MED_SØKER',
+  BARN_BOR_I_EØS_MED_ANNEN_FORELDER = 'BARN_BOR_I_EØS_MED_ANNEN_FORELDER',
+  BARN_BOR_I_NORGE = 'BARN_BOR_I_NORGE',
+  BARN_BOR_I_NORGE_MED_SØKER = 'BARN_BOR_I_NORGE_MED_SØKER',
+  BARN_BOR_ALENE_I_ANNET_EØS_LAND = 'BARN_BOR_ALENE_I_ANNET_EØS_LAND',
 }
 
 const KompetanseValg: Record<
@@ -27,6 +33,30 @@ const KompetanseValg: Record<
   BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER: {
     title: 'Barn bor i Storbritannia med annen forelder',
     value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER,
+  },
+  BARN_BOR_I_EØS: {
+    title: 'Barn bor i EØS',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_EØS,
+  },
+  BARN_BOR_I_EØS_MED_SØKER: {
+    title: 'Barn bor i EØS med søker',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_EØS_MED_SØKER,
+  },
+  BARN_BOR_I_EØS_MED_ANNEN_FORELDER: {
+    title: 'Barn bor i EØS med annen forelder',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_EØS_MED_ANNEN_FORELDER,
+  },
+  BARN_BOR_I_NORGE: {
+    title: 'Barn bor i Norge',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_NORGE,
+  },
+  BARN_BOR_I_NORGE_MED_SØKER: {
+    title: 'Barn bor i Norge med søker',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_I_NORGE_MED_SØKER,
+  },
+  BARN_BOR_ALENE_I_ANNET_EØS_LAND: {
+    title: 'Barn bor alene i annet EØS-land',
+    value: UtdypendeVilkårsvurderingForEØS.BARN_BOR_ALENE_I_ANNET_EØS_LAND,
   },
 };
 


### PR DESCRIPTION
Favro: NAV-17079

For at begrunnelser som trigges av vilkår skal bli tilgjengelige må de matche både med vilkårsresultatet for utgjørende vilkår OG valgt utdypende vilkår. 

Utdypende vilkår er påkrevd for EØS `BOSATT_I_RIKET` og `BOR_MED_SØKER`. Hvis saksbehandler velger et utdypende vilkår som ikke finnes som trigger i sanity kan ikke begrunnelsen bli tilgjengelig. Derfor må vi ha alle tilgjengelige utdypende vilkår for disse vilkårene tilgjengelige som triggere i sanity.

Se https://github.com/navikt/familie-ba-sak-frontend/blob/4a2f588f9210adb44d154785b12715e93032da32/src/frontend/typer/vilk%C3%A5r.ts#L254 og  https://github.com/navikt/familie-ba-sak-frontend/blob/4a2f588f9210adb44d154785b12715e93032da32/src/frontend/typer/vilk%C3%A5r.ts#L260