### PR TITLE
Ny brevperiodetype IKKE_RELEVANT

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/brevPeriodetype.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/sanityMappeFelt/brevPeriodetype.tsx
@@ -6,6 +6,7 @@ export enum BrevPeriodetype {
   INGEN_UTBETALING = 'INGEN_UTBETALING',
   INGEN_UTBETALING_UTEN_PERIODE = 'INGEN_UTBETALING_UTEN_PERIODE',
   FORTSATT_INNVILGET = 'FORTSATT_INNVILGET',
+  IKKE_RELEVANT = 'IKKE_RELEVANT',
 }
 
 export const brevPeriodeTypeTilMenyValg = (
@@ -21,6 +22,8 @@ export const brevPeriodeTypeTilMenyValg = (
         return 'Ingen utbetaling uten periode';
       case BrevPeriodetype.FORTSATT_INNVILGET:
         return 'Fortsatt innvilget';
+      case BrevPeriodetype.IKKE_RELEVANT:
+        return 'Ikke relevant';
     }
   };
 


### PR DESCRIPTION
For å kunne gjøre begrunnelser valgbare uavhenging av brevperiodetype.

Hører sammen med https://github.com/navikt/familie-ba-sak/pull/4271
