### PR TITLE
Automatisk valutajustering: Utbetalinger-avsnitt

### DIFF
--- a/config/felles.ts
+++ b/config/felles.ts
@@ -8,6 +8,7 @@ export const ekskluderesForEf: string[] = [
   DokumentNavn.DELMAL,
   DokumentNavn.DOKUMENT,
   DokumentNavn.PERIODE,
+  DokumentNavn.UTBETALINGER,
   BegrunnelseDokumentNavn.BA_BEGRUNNELSE,
   KSBegrunnelseDokumentNavn.KS_BEGRUNNELSE,
 ];

--- a/src/komponenter/UtbetalingerBeskrivelse.tsx
+++ b/src/komponenter/UtbetalingerBeskrivelse.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export const UtbetalingerBeskrivelse = () => (
+  <p>
+    I dokumenter hvor denne malen er brukt vil det legges til en tabell med utbetalinger fra siste
+    endringstidspunkt og fremover.
+  </p>
+);

--- a/src/schemas/Delmal.js
+++ b/src/schemas/Delmal.js
@@ -5,6 +5,7 @@ import TekstStyles from '../util/TekstStyles';
 import { flettefeltAvsnitt } from './avsnitt/flettefeltAvsnitt';
 import decorators from '../util/decorators';
 import { apiNavnValideringer } from '../util/valideringer';
+import { utbetalingerAvsnitt } from './avsnitt/utbetalingerAvsnitt';
 
 const editor = (maalform, tittel) => ({
   name: maalform,
@@ -12,6 +13,7 @@ const editor = (maalform, tittel) => ({
   type: SanityTyper.ARRAY,
   of: [
     flettefeltAvsnitt,
+    utbetalingerAvsnitt,
     {
       type: SanityTyper.BLOCK,
       marks: {

--- a/src/schemas/Dokument.js
+++ b/src/schemas/Dokument.js
@@ -6,6 +6,7 @@ import { flettefeltAvsnitt } from './avsnitt/flettefeltAvsnitt';
 import { peroideAvsnitt } from './avsnitt/periodeAvsnitt';
 import decorators from '../util/decorators';
 import { apiNavnValideringer } from '../util/valideringer';
+import { utbetalingerAvsnitt } from './avsnitt/utbetalingerAvsnitt';
 
 const editor = (maalform, tittel) => ({
   name: maalform,
@@ -15,6 +16,7 @@ const editor = (maalform, tittel) => ({
     delmalAvsnitt(maalform),
     flettefeltAvsnitt,
     peroideAvsnitt,
+    utbetalingerAvsnitt,
     {
       type: SanityTyper.BLOCK,
       marks: {

--- a/src/schemas/avsnitt/delmalAvsnitt.ts
+++ b/src/schemas/avsnitt/delmalAvsnitt.ts
@@ -22,6 +22,12 @@ export const delmalAvsnitt = maalform => ({
       validation: Rule => [Rule.required().error('Velg om delmalen alltid skal med.')],
     },
     {
+      title: 'Delmalen skal begynne på neste side',
+      name: DokumentNavn.SKAL_BEGYNNE_PÅ_NY_SIDE,
+      type: SanityTyper.BOOLEAN,
+      description: 'Dersom denne er på vil delmalen begynne på ny side',
+    },
+    {
       name: 'lagNy',
       type: SanityTyper.STRING,
       description: 'En knapp for å lage ny delmal',

--- a/src/schemas/avsnitt/utbetalingerAvsnitt.ts
+++ b/src/schemas/avsnitt/utbetalingerAvsnitt.ts
@@ -1,0 +1,22 @@
+import { DokumentNavn, SanityTyper } from '../../util/typer';
+import { AiOutlineUnorderedList } from 'react-icons/ai';
+import { UtbetalingerBeskrivelse } from '../../komponenter/UtbetalingerBeskrivelse';
+
+export const utbetalingerAvsnitt = {
+  name: DokumentNavn.UTBETALINGER,
+  type: SanityTyper.OBJECT,
+  title: 'Utbetalinger',
+  fields: [
+    {
+      name: 'utbetalingerbeskrivelse',
+      type: SanityTyper.STRING,
+      components: { input: UtbetalingerBeskrivelse },
+    },
+  ],
+  preview: {
+    prepare: () => ({
+      media: AiOutlineUnorderedList,
+      title: 'Utbetalinger',
+    }),
+  },
+};

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -43,6 +43,8 @@ export enum DokumentNavn {
   FRITTSTÅENDE_BREV = 'frittstaendeBrev',
   FOR_FRITTSTÅENDE_BREV = 'valgtSomFrittstaendeBrev',
   TITTEL_DOKUMENTOVERSIKT = 'tittelDokumentoversikt',
+  UTBETALINGER = 'utbetalinger',
+  SKAL_BEGYNNE_PÅ_NY_SIDE = 'skalBegynnePaaNySide',
 }
 
 export enum SanityTyper {


### PR DESCRIPTION
Favro: [NAV-18502](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18502)

Vi ønsker muligheten til å legge til en utbetalingstabell i utvalgte dokumenter. Oppretter her et Utbetalinger-avsnitt, og gjør den tilgjengelig i delmaler. Selve avsnittet inneholder ingenting og blir bare brukt for å fortelle `familie-brev` at vi ønsker å tegne ut en tabell over utbetalinger.

Har i tillegg lagt til feltet: `skalBegynnePaaNySide` på delmal-avsnitt som gir oss mulighet til å styre om et avsnitt skal begynne på ny side eller ikke fra Sanity.