### PR TITLE
Sammensatt kontrollsak: Lagt til støtte for sammensatt kontrollsak fritekst i brev

### DIFF
--- a/src/komponenter/SammensattKontrollsakFritekstBeskrivelse.tsx
+++ b/src/komponenter/SammensattKontrollsakFritekstBeskrivelse.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export const SammensattKontrollsakFritekstBeskrivelse = () => (
+  <p>
+    I dokumenter hvor denne malen er brukt vil det i alle sammensatte kontrollsaker vises en
+    fritekst fremfor perioder og hjemler
+  </p>
+);

--- a/src/schemas/Dokument.js
+++ b/src/schemas/Dokument.js
@@ -7,6 +7,7 @@ import { peroideAvsnitt } from './avsnitt/periodeAvsnitt';
 import decorators from '../util/decorators';
 import { apiNavnValideringer } from '../util/valideringer';
 import { utbetalingerAvsnitt } from './avsnitt/utbetalingerAvsnitt';
+import { sammensattKontrollsakFritekstAvsnitt } from './avsnitt/sammensattKontrollsakFritekstAvsnitt';
 
 const editor = (maalform, tittel) => ({
   name: maalform,
@@ -17,6 +18,7 @@ const editor = (maalform, tittel) => ({
     flettefeltAvsnitt,
     peroideAvsnitt,
     utbetalingerAvsnitt,
+    sammensattKontrollsakFritekstAvsnitt,
     {
       type: SanityTyper.BLOCK,
       marks: {

--- a/src/schemas/avsnitt/sammensattKontrollsakFritekstAvsnitt.ts
+++ b/src/schemas/avsnitt/sammensattKontrollsakFritekstAvsnitt.ts
@@ -1,0 +1,22 @@
+import { DokumentNavn, SanityTyper } from '../../util/typer';
+import { AiOutlineUnorderedList } from 'react-icons/ai';
+import { SammensattKontrollsakFritekstBeskrivelse } from '../../komponenter/SammensattKontrollsakFritekstBeskrivelse';
+
+export const sammensattKontrollsakFritekstAvsnitt = {
+  name: DokumentNavn.SAMMENSATT_KONTROLLSAK_FRITEKST,
+  type: SanityTyper.OBJECT,
+  title: 'Sammensatt kontrollsak fritekst',
+  fields: [
+    {
+      name: 'sammensattKontrollsakFritekstBeskrivelse',
+      type: SanityTyper.STRING,
+      components: { input: SammensattKontrollsakFritekstBeskrivelse },
+    },
+  ],
+  preview: {
+    prepare: () => ({
+      media: AiOutlineUnorderedList,
+      title: 'Sammensatt kontrollsak fritekst',
+    }),
+  },
+};

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -45,6 +45,7 @@ export enum DokumentNavn {
   TITTEL_DOKUMENTOVERSIKT = 'tittelDokumentoversikt',
   UTBETALINGER = 'utbetalinger',
   SKAL_BEGYNNE_PÅ_NY_SIDE = 'skalBegynnePaaNySide',
+  SAMMENSATT_KONTROLLSAK_FRITEKST = 'sammensattKontrollsakFritekst',
 }
 
 export enum SanityTyper {


### PR DESCRIPTION
Lagt til `SammensattKontrollsakFritekstAvsnitt`, som nå kan legges til på `Dokument`, slik at fritekst i sammensatte kontrollsaker kan vises i brev.