### PR TITLE
Gå bort i fra ks-v2

### DIFF
--- a/config/felles.ts
+++ b/config/felles.ts
@@ -29,4 +29,4 @@ const hentDataset = () => window.location.pathname.split('/')[1];
 
 export const erEf = () => ['ef-brev', 'ef-test', 'testdata'].includes(hentDataset());
 export const erBa = () => ['ba-v2', 'ba-brev', 'ba-test', 'testdata'].includes(hentDataset());
-export const erKs = () => ['ks-v2', 'ks-brev', 'ks-test', 'testdata'].includes(hentDataset());
+export const erKs = () => ['ks-brev', 'ks-test', 'testdata'].includes(hentDataset());

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -74,15 +74,6 @@ export default defineConfig([
     auth: auth,
   },
   {
-    name: 'ks-v2',
-    title: 'KS-v2',
-    projectId: PROSJEKT_ID,
-    dataset: 'ks-v2',
-    basePath: '/ks-v2',
-    plugins: [sharedConfig()],
-    auth: auth,
-  },
-  {
     name: 'ks-test',
     title: 'KS-test',
     projectId: PROSJEKT_ID,


### PR DESCRIPTION
Nå som vi er live med lovendringen så tenker jeg at vi kan gå tilbake til KS-brev.
Innholdet i V2 er migrert til ks-brev.

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21842