### PR TITLE
Legger til nytt flettefelt maanedOgAarFoorVedtaksperiode ifbm innvilgelse etter fulltidsplass  i nytt regelverk

### DIFF
--- a/src/schemas/baks/begrunnelse/ks-sak/flettefelter.ts
+++ b/src/schemas/baks/begrunnelse/ks-sak/flettefelter.ts
@@ -3,4 +3,5 @@ import { flettefelter as baFlettefelter } from '../ba-sak/typer';
 export const flettefelter = [
   ...baFlettefelter,
   { title: 'Antall timer barnehageplass', value: 'antallTimerBarnehageplass' },
+  { title: 'Måned og år før vedtaksperiode', value: 'maanedOgAarFoorVedtaksperiode' },
 ];


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24216
PR i ks-sak: https://github.com/navikt/familie-ks-sak/pull/1083

I regelverk 2025 for KS, så skal man ha en liten karensperiode dersom man går fra fulltidbarnehageplass til deltid eller ingen.
Dette vil si at slutter du i midten av mars 2025, så vil du ikke få innvilget før mai 2025.

Vi legger inn derfor et nytt flettefelt maanedOgAarFoorVedtaksperiode, og begrunnelse slik at man kan referere til 'karens' måneden man ikke fikk KS selvom barnet ikke gikk i barnehage hele april.