### PR TITLE
Pin actions med ratchet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
     day: "sunday"
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    workflows:
+      patterns:
+        - "*"

--- a/.github/workflows/backup.yaml
+++ b/.github/workflows/backup.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Backup ba dataset
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: Installer sanity
         run: yarn global add @sanity/cli && sanity install
@@ -23,7 +23,7 @@ jobs:
         run: sanity dataset export ba-brev backups/ba-sak.tar.gz
 
       - name: Upload ba-sak.tar.gz
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: backup-ba
           path: backups/ba-sak.tar.gz
@@ -35,7 +35,7 @@ jobs:
     name: Backup ef dataset
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: Installer sanity
         run: yarn global add @sanity/cli && sanity install
@@ -46,7 +46,7 @@ jobs:
         run: sanity dataset export ef-brev backups/ef-sak.tar.gz
 
       - name: Upload ef-sak.tar.gz
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: backup-ef
           path: backups/ef-sak.tar.gz

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -11,10 +11,10 @@ jobs:
     name: Deploy
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           cache: yarn
           cache-dependency-path: ./package.json

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           cache: yarn
           cache-dependency-path: ./package.json


### PR DESCRIPTION
💰 Hva forsøker du å løse i denne PR'en
Ta i bruk ratchet og dependabot for github actions. Som vil gi oss up-to-date versjoner av workflows vi bruker. Å lene seg på versjonnummer alene utgir en sikkerhetsrisiko.