### PR TITLE
Flettefeltet må endres til maanedOgAarFoerVedtaksperiode etter justering i ks sak

### DIFF
--- a/src/schemas/baks/begrunnelse/ks-sak/flettefelter.ts
+++ b/src/schemas/baks/begrunnelse/ks-sak/flettefelter.ts
@@ -3,5 +3,5 @@ import { flettefelter as baFlettefelter } from '../ba-sak/typer';
 export const flettefelter = [
   ...baFlettefelter,
   { title: 'Antall timer barnehageplass', value: 'antallTimerBarnehageplass' },
-  { title: 'Måned og år før vedtaksperiode', value: 'maanedOgAarFoorVedtaksperiode' },
+  { title: 'Måned og år før vedtaksperiode', value: 'maanedOgAarFoerVedtaksperiode' },
 ];


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24605

maanedOgAarFoorVedtaksperiode ble endret i pullrequesten https://github.com/navikt/familie-ks-sak/pull/1124, men man hadde ikke endret på det i sanity. Dette fører til at det kræsjer for begrunnelsene som bruker måneden før vedtaksperioden fordi dette feltet ble sendt med feil apinavn.