### PR TITLE
Vi fikser preview bug etter dependency update

### DIFF
--- a/src/schemas/avsnitt/delmalAvsnitt.ts
+++ b/src/schemas/avsnitt/delmalAvsnitt.ts
@@ -37,12 +37,14 @@ export const delmalAvsnitt = maalform => ({
   validation: Rule => [Rule.required().error('Ingen delmal valgt')],
   preview: {
     select: {
-      _id: `${DokumentNavn.DELMAL_REFERANSE}._ref`,
+      delmalReferanse: `${DokumentNavn.DELMAL_REFERANSE}`,
     },
   },
   components: {
     preview: (props: any) => {
-      return DelmalBlockComponent(props, maalform, props._id);
+      const ref = props?.delmalReferanse?._ref;
+
+      return DelmalBlockComponent(props, maalform, ref);
     },
   },
 });

--- a/src/schemas/avsnitt/flettefeltAvsnitt.ts
+++ b/src/schemas/avsnitt/flettefeltAvsnitt.ts
@@ -25,12 +25,14 @@ export const flettefeltAvsnitt = {
   ],
   preview: {
     select: {
-      _ref: `${DokumentNavn.FLETTEFELT_REFERANSE}._ref`,
+      flettefeltReferanse: `${DokumentNavn.FLETTEFELT_REFERANSE}`,
     },
   },
   components: {
     preview: (props: any) => {
-      return FlettefeltBlockComponent(props._ref);
+      const ref = props?.flettefeltReferanse?._ref;
+
+      return FlettefeltBlockComponent(ref);
     },
   },
 };


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25100

Denne requesten av dependabot brakk forhåndsvisning av delmal og flettefelt:
https://github.com/navikt/familie-sanity-brev/pull/701

Det kom med noe breaking changes i hvordan vi henter ut felter
 
<img width="517" alt="Screenshot 2025-05-05 at 14 30 58" src="https://github.com/user-attachments/assets/720c0bb8-8dd1-4522-8958-e046618bb70f" />
<img width="553" alt="Screenshot 2025-05-05 at 14 31 03" src="https://github.com/user-attachments/assets/b2bdaf04-4686-4897-837e-5c450121ebcb" />

Jeg har nå fikset det slik at det ser sånn ut:
<img width="504" alt="Screenshot 2025-05-05 at 14 31 25" src="https://github.com/user-attachments/assets/43da0b0c-444c-4104-8f00-e2e779585ce2" />
<img width="543" alt="Screenshot 2025-05-05 at 14 31 29" src="https://github.com/user-attachments/assets/a7ad41a7-3a0c-474d-ad8c-5ae56e667aef" />

