### PR TITLE
Legg til bosatt på svalbard trigger

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -48,6 +48,7 @@ export const eøsFlettefelter = [
 export enum VilkårTriggere {
   VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
   MEDLEMSKAP = 'MEDLEMSKAP',
+  BOSATT_PÅ_SVALBARD = 'BOSATT_PÅ_SVALBARD',
   MANGLER_OPPLYSNINGER = 'MANGLER_OPPLYSNINGER',
   SATSENDRING = 'SATSENDRING',
   BARN_MED_6_ÅRS_DAG = 'BARN_MED_6_ÅRS_DAG',
@@ -64,6 +65,7 @@ export const lovligOppholdTriggerTyper = [VilkårTriggere.VURDERING_ANNET_GRUNNL
 export const bosattIRiketTriggerTyper = [
   VilkårTriggere.VURDERING_ANNET_GRUNNLAG,
   VilkårTriggere.MEDLEMSKAP,
+  VilkårTriggere.BOSATT_PÅ_SVALBARD,
 ];
 export const giftPartnerskapTriggerTyper = [
   VilkårTriggere.VURDERING_ANNET_GRUNNLAG,
@@ -93,6 +95,10 @@ export const vilkårTriggerTilMenynavn: Record<VilkårTriggere, { title: string;
   MEDLEMSKAP: {
     title: 'Medlemskap',
     value: VilkårTriggere.MEDLEMSKAP,
+  },
+  BOSATT_PÅ_SVALBARD: {
+    title: 'Bosatt på Svalbard',
+    value: VilkårTriggere.BOSATT_PÅ_SVALBARD,
   },
   BARN_MED_6_ÅRS_DAG: { title: 'Barn med 6 års dag', value: VilkårTriggere.BARN_MED_6_ÅRS_DAG },
   MANGLER_OPPLYSNINGER: {

--- a/src/schemas/baks/begrunnelse/ks-sak/nasjonal/nasjonaleTriggere/utdypendeVilkårsvurderinger.ts
+++ b/src/schemas/baks/begrunnelse/ks-sak/nasjonal/nasjonaleTriggere/utdypendeVilkårsvurderinger.ts
@@ -4,6 +4,7 @@ import { erNasjonalBegrunnelse } from '../../eøs/eøsTriggere/utils';
 export enum UtdypendeVilkårsvurderinger {
   VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
   DELT_BOSTED = 'DELT_BOSTED',
+  BOSATT_PÅ_SVALBARD = 'BOSATT_PÅ_SVALBARD',
   DELT_BOSTED_SKAL_IKKE_DELES = 'DELT_BOSTED_SKAL_IKKE_DELES',
   ADOPSJON = 'ADOPSJON',
   SOMMERFERIE = 'SOMMERFERIE',
@@ -24,6 +25,10 @@ const utdypendeVilkårsvurderingerValg: Record<
   DELT_BOSTED_SKAL_IKKE_DELES: {
     title: 'Delt bosted - skal ikke deles',
     value: UtdypendeVilkårsvurderinger.DELT_BOSTED_SKAL_IKKE_DELES,
+  },
+  BOSATT_PÅ_SVALBARD: {
+    title: 'Bosatt på Svalbard',
+    value: UtdypendeVilkårsvurderinger.BOSATT_PÅ_SVALBARD,
   },
   ADOPSJON: {
     title: 'Adopsjon',


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25335

Vi legger til bosatt på svalbard trigger for både ks-sak og ba-sak.
Dette tillatter oss å tilgjengeliggjøre begrunnelser basert på det utdypende vilkåret bosatt på svalbard.

KS-SAK:
<img width="310" alt="ks-sak" src="https://github.com/user-attachments/assets/8907b30b-9567-40ce-a214-cb22e62a35ff" />

BA-SAK:
<img width="255" alt="ba sak" src="https://github.com/user-attachments/assets/f013d8d4-1e5f-4e9f-8e35-ed1079d40f03" />
<img width="524" alt="ba-sak" src="https://github.com/user-attachments/assets/28a0fc00-003c-4e59-88e1-3732a7f178fd" />
