### PR TITLE
Legger til trigger bosatt i finnmark nord troms for bosatt i riket vilkåret

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -99,7 +99,7 @@ export const vilkårTriggerTilMenynavn: Record<VilkårTriggere, { title: string;
     value: VilkårTriggere.MEDLEMSKAP,
   },
   BOSATT_I_FINNMARK_NORD_TROMS: {
-    title: 'Bosatt i Finnmark/Nord Troms',
+    title: 'Bosatt i Finnmark/Nord-Troms',
     value: VilkårTriggere.BOSATT_I_FINNMARK_NORD_TROMS,
   },
   BOSATT_PÅ_SVALBARD: {

--- a/src/schemas/baks/begrunnelse/ba-sak/typer.ts
+++ b/src/schemas/baks/begrunnelse/ba-sak/typer.ts
@@ -49,6 +49,7 @@ export enum VilkårTriggere {
   VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
   MEDLEMSKAP = 'MEDLEMSKAP',
   BOSATT_PÅ_SVALBARD = 'BOSATT_PÅ_SVALBARD',
+  BOSATT_I_FINNMARK_NORD_TROMS = 'BOSATT_I_FINNMARK_NORD_TROMS',
   MANGLER_OPPLYSNINGER = 'MANGLER_OPPLYSNINGER',
   SATSENDRING = 'SATSENDRING',
   BARN_MED_6_ÅRS_DAG = 'BARN_MED_6_ÅRS_DAG',
@@ -66,6 +67,7 @@ export const bosattIRiketTriggerTyper = [
   VilkårTriggere.VURDERING_ANNET_GRUNNLAG,
   VilkårTriggere.MEDLEMSKAP,
   VilkårTriggere.BOSATT_PÅ_SVALBARD,
+  VilkårTriggere.BOSATT_I_FINNMARK_NORD_TROMS,
 ];
 export const giftPartnerskapTriggerTyper = [
   VilkårTriggere.VURDERING_ANNET_GRUNNLAG,
@@ -95,6 +97,10 @@ export const vilkårTriggerTilMenynavn: Record<VilkårTriggere, { title: string;
   MEDLEMSKAP: {
     title: 'Medlemskap',
     value: VilkårTriggere.MEDLEMSKAP,
+  },
+  BOSATT_I_FINNMARK_NORD_TROMS: {
+    title: 'Bosatt i Finnmark/Nord Troms',
+    value: VilkårTriggere.BOSATT_I_FINNMARK_NORD_TROMS,
   },
   BOSATT_PÅ_SVALBARD: {
     title: 'Bosatt på Svalbard',


### PR DESCRIPTION
Vi legger til trigger bosatt i finnmark/nord troms for bosatt i riket vilkåret.
På denne måten blir det mulig å tilgjengeliggjøre begrunnelser basert på om bosatt i finnmark/nord troms er valgt som utdypende vilkårsvurdering.

<img width="370" alt="Bosatt i finnmark nordtroms" src="https://github.com/user-attachments/assets/53fa4af9-2a09-4a84-862e-0c067a913f80" />
