### PR TITLE
Legger til appId slik at sanity deploy vet hvilken app studiot skal d…

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -6,4 +6,7 @@ export default defineCliConfig({
   api: {
     projectId: PROSJEKT_ID,
   },
+  deployment: {
+    appId: 'a5127a088702861473521b94',
+  },
 });


### PR DESCRIPTION
…eployes til


Deploy feiler: https://github.com/navikt/familie-sanity-brev/actions/runs/23133465266/job/67191682781

https://reference.sanity.io/_sanity/sdk-react/#deployment

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28083)

Hentet med `npx sanity deploy`
<img width="1128" height="492" alt="image" src="https://github.com/user-attachments/assets/2ddbd92a-51c2-4462-bc21-2ba5ffcf1edd" />
