### PR TITLE
Legger til muligheten for å velge hvilket regelverk brevet skal vises på

### DIFF
--- a/src/schemas/avansertDokument/AvansertDokument.tsx
+++ b/src/schemas/avansertDokument/AvansertDokument.tsx
@@ -58,6 +58,20 @@ export default {
       type: SanityTyper.BOOLEAN,
     },
     {
+      title: 'Regelverk',
+      name: DokumentNavn.REGELVERK_VERSJON,
+      description: 'Hvilke behandlingsregler gjelder brevet for?',
+      type: SanityTyper.STRING,
+      options: {
+        list: [
+          { title: 'Gammelt regelverk', value: 'gammelt_regelverk' },
+          { title: 'Nytt regelverk (2026)', value: 'nytt_regelverk' },
+          { title: 'Begge regelverk', value: 'begge_regelverk' },
+        ],
+        layout: 'radio',
+      },
+    },
+    {
       title: 'Frittstående brev',
       name: DokumentNavn.FRITTSTÅENDE_BREV,
       type: SanityTyper.OBJECT,

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -47,6 +47,7 @@ export enum DokumentNavn {
   UTBETALINGER = 'utbetalinger',
   SKAL_BEGYNNE_PÅ_NY_SIDE = 'skalBegynnePaaNySide',
   SAMMENSATT_KONTROLLSAK_FRITEKST = 'sammensattKontrollsakFritekst',
+  REGELVERK_VERSJON = 'regelverkVersjon',
 }
 
 export enum SanityTyper {


### PR DESCRIPTION
Lagt til mulighet for å tagge brev med hvilket regelverk det skal være mulig å velge de på.
Saker som har regelverkVersjon = null (ikke huket av i sanity) eller "begge" vises i begge for bakoverkompatabilitet frem til man tar en avgjørelse på hver brevmal.

For behandlinger som behandles etter nytt regelverk vises derfor brev tagget med "begge_regelverk", "nytt_regelverk" og de som ikke er tagget

For behandlinger som behandles etter gammelt regelverk vises derfor brev tagget med "begge_regelverk", "gammelt_regelverk" og de som ikke er tagget

Testet ved å lage 3 nye brev med valgene av regelverk enten "begge_regelverk", "gammelt_regelverk" eller "nytt_regelverk", og sjekket at de dukker opp i riktig flyt som beskrevet over

<img width="530" height="154" alt="image" src="https://github.com/user-attachments/assets/66d904d5-b00f-4ee4-837e-241f416de17e" />
