### PR TITLE
NAV-29967: Legg til flagg for splitting av begrunnelse på søknadstidspunkt

### DIFF
--- a/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
+++ b/src/schemas/baks/begrunnelse/ba-sak/begrunnelse.tsx
@@ -222,6 +222,14 @@ const begrunnelse = {
         'Huk av dersom det skal dukke opp mulighet til å skrive inn fritekst når begrunnelsen er valgt i BA-SAK',
     },
     {
+      title: 'Splitt på søknadstidspunkt',
+      type: SanityTyper.BOOLEAN,
+      name: BegrunnelseDokumentNavn.SPLITT_PÅ_SØKNADSTIDSPUNKT,
+      description:
+        'Huk av dersom begrunnelsen skal deles i én tekst per søknadstidspunkt når barna i en ' +
+        'endret utbetalingsperiode har ulike søknadstidspunkt. Krever at brevteksten fletter inn "Søknadstidspunkt".',
+    },
+    {
       title: 'Vilkår',
       description:
         'Hvilke vilkår som må være utgjørende for at begrunnelsen skal vises. ' +

--- a/src/util/typer.ts
+++ b/src/util/typer.ts
@@ -88,6 +88,7 @@ export enum BegrunnelseDokumentNavn {
   UTVIDET_BARNETRYGD_TRIGGERE = 'utvidetBarnetrygdTriggere',
   IKKE_I_BRUK = 'ikkeIBruk',
   STØTTER_FRITEKST = 'stotterFritekst',
+  SPLITT_PÅ_SØKNADSTIDSPUNKT = 'splittPaaSoknadstidspunkt',
 }
 
 export enum EØSBegrunnelseDokumentNavn {


### PR DESCRIPTION
### 📮 Favro: NAV-29967

### 💰 Hva skal gjøres, og hvorfor?
Legger til et nytt felt `Splitt på søknadstidspunkt` (`splittPaaSoknadstidspunkt`) på begrunnelser for BA-SAK.

Når barna i en endret utbetalingsperiode har ulike søknadstidspunkt, blir søknadstidspunktet i dag utledet fra alle personene i begrunnelsen, mens teksten kun nevner et utvalg av barna. Resultatet er at brevet kan vise feil søknadstidspunkt.

Med dette flagget kan saksbehandler markere i Sanity at begrunnelsen skal deles i én tekst per søknadstidspunkt. BA-SAK leser flagget og splitter begrunnelsen tilsvarende (se tilhørende PR i familie-ba-sak).

Flagget forutsetter at brevteksten fletter inn `Søknadstidspunkt`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ordlyden på tittel og beskrivelse av feltet, slik at det er tydelig for de som setter det i Sanity.
